### PR TITLE
Align with updated RDF-star spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,53 @@
 
 # JSON-LD 1.1*
 
-This is the repository describes extensions to [JSON-LD 1.1][], [JSON-LD 1.1 API][], and [JSON-LD 1.1 Framing][] to support triples as node identifiers as defined by [RDF*]
+This is the repository describes extensions to [JSON-LD 1.1][], [JSON-LD 1.1 API][], and [JSON-LD 1.1 Framing][] to support triples as node identifiers as defined by [RDF-star]
 developed by the [JSON for Linking Data Community Group](https://www.w3.org/community/json-ld/). The editors’ draft of the Note can also be [read directly](https://json-ld.github.io/json-ld-star/).
 
-## Contributing to the Repository
+The JSON-LD-star Test Suite is a set of tests that can
+be used to verify JSON-LD Processor for the RDF-star extensions to JSON-LD.
 
-Use the standard fork, branch, and pull request workflow to propose changes to the specification. Please make branch names informative—by including the issue or bug number for example.
+More information and an RDFS definition of the test vocabulary can be found at [vocab](https://w3c.github.io/json-ld-api/tests/vocab).
 
-Editorial changes that improve the readability of the spec or correct spelling or grammatical mistakes are welcome.
+## General instructions for running the JSON-LD Test suites
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md), about licensing contributions.
+Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the `rdfstar` option set to `true` for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF-star mode.
 
+## Running tests
+
+The top-level [manifest](manifest.jsonld) references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
+
+Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:
+
+* For JSON-Ld-star tests, the `specVersion` is set to `JSON-LD-star`.
+* Some tests may have a `requires` property, indicating some optional behavior described by a test vocabulary term. Tests that use JSON-LD-star functionality have `"requires": "JSON-LD-star"` specified.
+
+## Contributing Tests
+
+If you would like to contribute a new test or a fix to an existing test,
+please follow these steps:
+
+1. Notify the JSON-LD Community mailing list, public-linked-json@w3.org,
+   that you will be creating a new test or fix and the purpose of the
+   change.
+2. Clone the git repository: git://github.com/json-ld/json-ld-star.git
+3. Make your changes and submit them via github, or via a 'git format-patch'
+   to the [JSON-LD Community Group mailing list](mailto:public-linked-json@w3.org).
+
+## Distribution
+
+Distributed under the [W3C Test Suite License](http://www.w3.org/Consortium/Legal/2008/04-testsuite-license). To contribute to a W3C Test Suite, see the [policies and contribution forms](http://www.w3.org/2004/10/27-testcases).
+
+## Disclaimer
+
+UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.
 
 ## Code of Conduct
 
 W3C functions under a [code of conduct](https://www.w3.org/Consortium/cepc/).
-)
 
-[RDF*]:                 https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/
+[RDF-star]:                 https://w3c.github.io/rdf-star/rdf-star-cg-spec.html
 [JSON-LD 1.1]:          https://w3.org/TR/json-ld11
 [JSON-LD 1.1 API]:      https://w3.org/TR/json-ld11-api
 [JSON-LD 1.1 Framing]:  https://w3.org/TR/json-ld11-framing

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>JSON-LD*</title>
+<title>JSON-LD-star</title>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
 <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
 <script src="common/common.js" class="remove" defer></script>
@@ -9,7 +9,7 @@
   var respecConfig = {
     localBiblio: {
       "RDFStar": {
-        "title": "RDF* and SPARQL*",
+        "title": "RDF-star and SPARQL-star",
         "authors": [
           "Olaf Hartig",
           "Pierre-Antoine Champin"
@@ -20,7 +20,7 @@
         "date": "2021-01-01"
       },
       "JSON-LD-star-tests": {
-        "title": "JSON-LD* Test Suite",
+        "title": "JSON-LD-star Test Suite",
         "author": "Gregg Kellogg",
         "publisher": "W3C",
         "status": "unofficial",
@@ -339,7 +339,7 @@
   </div>
 
   <section id="conformance">
-    <p>A <a>JSON-LD* document</a> complies with this specification if it follows
+    <p>A <a>JSON-LD-star document</a> complies with this specification if it follows
       the normative statements in <a href="#grammar-extensions"></a>.
       For convenience, normative
       statements for documents are often phrased as statements on the properties of the document.</p>
@@ -372,20 +372,20 @@
   </section>
 
   <section class="informative">
-    <h2>JSON-LD*-specific Terms</h2>
+    <h2>JSON-LD-star-specific Terms</h2>
 
     <p>The Following terms are used within specific algorithms.</p>
 
     <dl data-sort>
-      <dt><dfn data-cite="RDFStar#dfn-dataset">RDF* dataset</dfn></dt><dd>
+      <dt><dfn data-cite="RDFStar#dfn-dataset">RDF-star dataset</dfn></dt><dd>
         An <a>RDF dataset</a> extended to allow the use of an
-        <a>RDF* graph</a> instead of a plain <a>RDF graph</a>.
+        <a>RDF-star graph</a> instead of a plain <a>RDF graph</a>.
       </dd>
-      <dt><dfn data-cite="RDFStar#dfn-graph">RDF* graph</dfn></dt><dd>
-        A set of <a>RDF* triples</a>.
+      <dt><dfn data-cite="RDFStar#dfn-graph">RDF-star graph</dfn></dt><dd>
+        A set of <a>RDF-star triples</a>.
       </dd>
-      <dt><dfn data-cite="RDFStar#dfn-triple">RDF* triple</dfn></dt><dd>
-        An <a data-cite="RDF11-CONCEPTS#dfn-rdf-triple">RDF triple</a> extended to allow an <a>RDF* triple</a> to be
+      <dt><dfn data-cite="RDFStar#dfn-triple">RDF-star triple</dfn></dt><dd>
+        An <a data-cite="RDF11-CONCEPTS#dfn-rdf-triple">RDF triple</a> extended to allow an <a>RDF-star triple</a> to be
         used in the <a>subject</a> or <a>object</a> position.
       </dd>
       <dt><dfn >Embedded Node</dfn></dt><dd>
@@ -397,8 +397,8 @@
         as `@context` or `@index`.
         An <a>embedded triples</a> is the representation of an <dfn data-cite="RDFStar#dfn-embedded-triple">embedded triple</dfn>.
       </dd>
-      <dt><dfn>JSON-LD* document</dfn></dt><dd>
-        A <a>JSON-LD* document</a> is a serialization of
+      <dt><dfn>JSON-LD-star document</dfn></dt><dd>
+        A <a>JSON-LD-star document</a> is a serialization of
         an <a>RDF dataset</a> as extended by [[RDFStar]].
       </dd>
       <dt><dfn>Annotation Object</dfn></dt><dd>
@@ -415,7 +415,7 @@
     <p>This specification adds the concepts of an <a>embedded node</a>
       and <a>annotation object</a> to JSON-LD in order to add the
       ability to make statements about individual <a>triples</a> in an
-      <a>RDF* Graph</a>.</p>
+      <a>RDF-star Graph</a>.</p>
 
     <p>An <a>embedded node</a> supports the ability to make one or more statements
       about a <a>triple</a>, represented by an <a>embedded node</a>, without that
@@ -430,7 +430,7 @@
         <button class="selected input" data-selects="compacted">Compacted (Input)</button>
         <button data-selects="expanded">Expanded</button>
         <button data-selects="flattened">Flattened</button>
-        <button data-selects="turtle">Turtle*</button>
+        <button data-selects="turtle">Turtle-star</button>
       </div>
       <pre class="compacted input selected"
            data-transform="updateExample"
@@ -501,7 +501,7 @@
         <button class="selected input" data-selects="compacted">Compacted (Input)</button>
         <button data-selects="expanded">Expanded</button>
         <button data-selects="flattened">Flattened</button>
-        <button data-selects="turtle">Turtle*</button>
+        <button data-selects="turtle">Turtle-star</button>
       </div>
       <pre class="compacted input selected"
            data-transform="updateExample"
@@ -595,7 +595,7 @@
           <button class="selected input" data-selects="compacted">Compacted (Input)</button>
           <button data-selects="expanded">Expanded</button>
           <button data-selects="flattened">Flattened</button>
-          <button data-selects="turtle">Turtle*</button>
+          <button data-selects="turtle">Turtle-star</button>
         </div>
         <pre class="compacted input selected"
              data-transform="updateExample"
@@ -672,7 +672,7 @@
           <button class="selected input" data-selects="compacted">Compacted (Input)</button>
           <button data-selects="expanded">Expanded</button>
           <button data-selects="flattened">Flattened</button>
-          <button data-selects="turtle">Turtle*</button>
+          <button data-selects="turtle">Turtle-star</button>
         </div>
         <pre class="compacted input selected"
              data-transform="updateExample"
@@ -769,7 +769,7 @@
           <button class="selected input" data-selects="compacted">Compacted (Input)</button>
           <button data-selects="expanded">Expanded</button>
           <button data-selects="flattened">Flattened</button>
-          <button data-selects="turtle">Turtle*</button>
+          <button data-selects="turtle">Turtle-star</button>
         </div>
         <pre class="compacted input selected"
              data-transform="updateExample"
@@ -863,7 +863,7 @@
 
       <p>While it is beyond the scope of this document to discuss use cases
         for these scenarios, it is an important notion of regularity
-        of expression, which is shared by formats such as <a data-cite="RDFStar#turtle-star">Turtle*</a>.</p>
+        of expression, which is shared by formats such as <a data-cite="RDFStar#turtle-star">Turtle-star</a>.</p>
 
       <p>Consider the following examples:</p>
 
@@ -873,7 +873,7 @@
           <button class="selected input" data-selects="compacted">Compacted (Input)</button>
           <button data-selects="expanded">Expanded</button>
           <button data-selects="flattened">Flattened</button>
-          <button data-selects="turtle">Turtle*</button>
+          <button data-selects="turtle">Turtle-star</button>
         </div>
         <pre class="compacted input selected"
              data-transform="updateExample"
@@ -967,7 +967,7 @@
           <button class="selected input" data-selects="compacted">Compacted (Input)</button>
           <button data-selects="expanded">Expanded</button>
           <button data-selects="flattened">Flattened</button>
-          <button data-selects="turtle">Turtle*</button>
+          <button data-selects="turtle">Turtle-star</button>
         </div>
         <pre class="compacted input selected"
              data-transform="updateExample"
@@ -1454,7 +1454,7 @@
       <h3>RDF Serialization/Deserialization Algorithms</h3>
 
       <p>The RDF transformation algorithms have minimal changes to allow
-        emit and consume <a>RDF* triples</a>.</p>
+        emit and consume <a>RDF-star triples</a>.</p>
 
       <section id="deserialize-json-ld-to-rdf-algorithm" class="algorithm">
         <h4>Deserialize JSON-LD to RDF Algorithm</h4>
@@ -1462,13 +1462,13 @@
         <p>The <a data-cite="JSON-LD11-API#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a>
           has minimal changes to allow
           an <a>embedded triple</a> to be used as the subject or object of
-          an <a>RDF* triple</a>,
+          an <a>RDF-star triple</a>,
           and to use <a>annotation objects</a>, where appropriate.</p>
 
         <p>After step 1.3.1 add the following step:</p>
         <ol>
           <li>If <var>subject</var> is a <a>string</a> with the
-            form of an <a>embedded node</a>. Transform it into an <a>RDF* triple</a>
+            form of an <a>embedded node</a>. Transform it into an <a>RDF-star triple</a>
             using the <a href="#object-to-rdf-algorithm">Object to RDF Algorithm</a>
             passing <var>subject</var> as <var>item</var>.</li>
         </ol>
@@ -1479,7 +1479,7 @@
 
         <p>The <a data-cite="JSON-LD11-API#object-to-rdf">Object to RDF</a> algorithm
           has a minimal update to allow a serialized <a>embedded node</a> to be transformed
-          into an <a>RDF* triple</a> by invoking the
+          into an <a>RDF-star triple</a> by invoking the
           <a href="#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a>
           recursively.</p>
 
@@ -1502,8 +1502,8 @@
                 use the <a data-cite="JSON-LD11-API#dfn-canonical-lexical-form">canonical lexical form</a>
                 as the key.</li>
               <li>The only entry in <var>dataset</var> will be a single
-                <a>RDF* triple</a> in the <a data-cite="JSON-LD11-API#dom-rdfdataset-defaultgraph">defaultGraph</a>.
-                Return that <a>RDF* triple</a>.</li>
+                <a>RDF-star triple</a> in the <a data-cite="JSON-LD11-API#dom-rdfdataset-defaultgraph">defaultGraph</a>.
+                Return that <a>RDF-star triple</a>.</li>
             </ol>
           </li>
         </ol>
@@ -1513,13 +1513,13 @@
         <h4>Serialize RDF as JSON-LD Algorithm</h4>
 
         <p>The <a data-cite="JSON-LD11-API#serialize-rdf-as-json-ld">Serialize RDF as JSON-LD Algorithm</a> algorithm
-          has updates to transform <a>RDF* triples</a> used as
+          has updates to transform <a>RDF-star triples</a> used as
           the subject or object of another triple to be used as the index
           into a <em>node map</em> and represented as <a>embedded nodes</a>.</p>
 
         <p>Change step 5.7.1 to the following steps:</p>
         <ol>
-          <li>If <var>subject</var> is an <a>RDF* triple</a>:
+          <li>If <var>subject</var> is an <a>RDF-star triple</a>:
             <ol>
               <li>Set <var>embedded subject</var> to the
                 value of the `@id` entry from the
@@ -1543,7 +1543,7 @@
 
         <p>Before step 5.7.4, add the following steps:</p>
         <ol>
-          <li>If <var>object</var> is an <a>RDF* triple</a>:
+          <li>If <var>object</var> is an <a>RDF-star triple</a>:
             <ol>
               <li>Set <var>embedded object</var> to the
                 value of the `@id` entry from the
@@ -1574,11 +1574,11 @@
         <h4>RDF to Object Conversion</h4>
 
         <p>The <a data-cite="JSON-LD11-API#rdf-to-object-conversion">RDF to Object Conversion</a> algorithm
-          has updates to transform <a>RDF* triples</a> into an <a>embedded node</a>.</p>
+          has updates to transform <a>RDF-star triples</a> into an <a>embedded node</a>.</p>
 
         <p>Before step 2, add the following steps:</p>
         <ol>
-          <li>Otherewise, if <var>value</var> is an <a>RDF* triple</a>:
+          <li>Otherewise, if <var>value</var> is an <a>RDF-star triple</a>:
             <ol>
               <li>Create a new <a>map</a> <var>embedded node</var>
                 with the <a>entry</a> `@id` whose value

--- a/index.html
+++ b/index.html
@@ -308,28 +308,10 @@
       </pre>
 
       <p>This NOTE explores an extension of JSON-LD which can allow
-        the value of an `@id` property to be a <a>node object</a> (with restrictions):</p>
-
-      <pre class="example"
-           data-transform="updateExample"
-           data-options="rdfstar=true"
-           title="Annotation on a node object">
-      <!--
-        {
-          "@context": {
-            "@base": "http://example.org/",
-            "@vocab": "http://example.org/"
-          },
-          "@id": "bob",
-          "age": {
-            "@value": 42,
-            "@annotation": {
-              "certainty": 0.8
-            }
-          }
-        }
-      -->
-      </pre>
+        the value of an `@id` property to be an <a>embedded node</a>,
+        and the description of an <a>annotation object</a> which serves as
+        a short-hand when the annotated value also is described
+        directly in the graph.</p>
     </section>
 
   <div class="informative hidden">
@@ -1067,8 +1049,7 @@
     </ul>
 
     <p><a>Embedded Nodes</a> can be considered as <a data-cite="rdf-primer#reification">reified</a> <a>triples</a>.</p>
-
-    <p class="issue" data-number="10"></p>
+    <p class="ednote">Align with [[RDFStar]].</p>
   </section>
 
   <section id="grammar-extensions">

--- a/reports/Rakefile
+++ b/reports/Rakefile
@@ -1,4 +1,4 @@
-task default: [ "manifests.nt", "earl.ttl", "earl.html" ]
+task default: [ "manifests.nt", "earl.jsonld", "index.html" ]
 
 desc "Create concatenated test manifests"
 file "manifests.nt" do
@@ -13,17 +13,20 @@ file "manifests.nt" do
         https://json-ld.github.io/json-ld-star/tests/toRdf-manifest.jsonld
     ).each do |man|
       puts "load #{man}"
-      g.load(man, unique_bnodes: true)
+      file = man.sub('https://json-ld.github.io/json-ld-star/', File.expand_path("../..", __FILE__) + '/')
+      g.load(man, unique_bnodes: true, base: man)
     end
   end
-  puts "write"
+  puts "write manifests.nt"
   RDF::NTriples::Writer.open("manifests.nt", unique_bnodes: true, validate: false) {|w| w << graph}
 end
 
 file "earl.jsonld" => %w(manifests.nt) do
+  puts "write earl.jsonld"
   %x(earl-report --format json -o earl.jsonld *.ttl)
 end
 
 file "index.html" => %w(template.haml earl.jsonld) do
+  puts "write index.html"
   %x(earl-report --json --format html --template template.haml -o index.html earl.jsonld)
 end

--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -104,6973 +104,49 @@
   },
   "@id": "",
   "@type": [
-    "Software",
-    "doap:Project"
+    "doap:Project",
+    "Software"
   ],
   "testSubjects": [
     {
       "@id": "https://rubygems.org/gems/json-ld",
       "@type": [
-        "Software",
         "TestSubject",
-        "doap:Project"
+        "doap:Project",
+        "Software"
       ],
       "homepage": "https://github.com/ruby-rdf/json-ld/",
+      "doapDesc": "JSON::LD parses and serializes JSON-LD into RDF and implements expansion, compaction and framing API interfaces for the Ruby RDF.rb library suite.",
+      "name": "JSON::LD",
+      "release": {
+        "@id": "_:b74",
+        "revision": "3.1.8"
+      },
+      "language": "Ruby",
       "developer": [
         {
           "@id": "https://greggkellogg.net/foaf#me",
           "@type": "foaf:Person",
           "foaf:name": "Gregg Kellogg"
         }
-      ],
-      "release": {
-        "@id": "_:b56",
-        "revision": "3.1.8"
-      },
-      "name": "JSON::LD",
-      "doapDesc": "JSON::LD parses and serializes JSON-LD into RDF and implements expansion, compaction and framing API interfaces for the Ruby RDF.rb library suite.",
-      "language": "Ruby"
+      ]
     }
   ],
-  "bibRef": "[[json-ld-star]]",
   "assertions": [
     "ruby-json-ld-earl.ttl"
-  ],
-  "entries": [
-    {
-      "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest",
-      "@type": [
-        "Report",
-        "mf:Manifest"
-      ],
-      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Expansion Algorithm](https://json-ld.github.io/json-ld-star#expansion-algorithm).",
-      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://w3c.github.io/json-ld-api/tests/",
-      "entries": [
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with embedded subject without rdfstar option.",
-          "mf:result": "invalid @id value",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st01-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b4",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b5",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b6",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node object with @annotation property is ignored without rdfstar option.",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st02-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st02-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b40",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "ignored annotation 1",
-          "assertions": [
-            {
-              "@id": "_:b41",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b42",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Value object with @annotation property is ignored without rdfstar option",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st03-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st03-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b248",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "ignored annotation 2",
-          "assertions": [
-            {
-              "@id": "_:b249",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b504",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having no @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st04-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st04-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b131",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b132",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b94",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having IRI @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st05-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st05-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b66",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 2",
-          "assertions": [
-            {
-              "@id": "_:b67",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b512",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having BNode @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st06-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st06-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b322",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 3",
-          "assertions": [
-            {
-              "@id": "_:b323",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b324",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having a type",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st07-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st07-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b130",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 4",
-          "assertions": [
-            {
-              "@id": "_:b159",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b129",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an IRI value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st08-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st08-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b219",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 5",
-          "assertions": [
-            {
-              "@id": "_:b220",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b155",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an BNode value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st09-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st09-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b192",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 6",
-          "assertions": [
-            {
-              "@id": "_:b193",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b194",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st10-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st10-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b27",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 7",
-          "assertions": [
-            {
-              "@id": "_:b28",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b221",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Illegal node with subject having no property",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st11-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b530",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 2",
-          "assertions": [
-            {
-              "@id": "_:b531",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b234",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Illegal node with subject having multiple properties",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st12-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b71",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 3",
-          "assertions": [
-            {
-              "@id": "_:b72",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b515",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Illegal node with subject having multiple types",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st13-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b505",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 4",
-          "assertions": [
-            {
-              "@id": "_:b506",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b241",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Illegal node with subject having type and property",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st14-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b404",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 5",
-          "assertions": [
-            {
-              "@id": "_:b405",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b466",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st15-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st15-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b152",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 8",
-          "assertions": [
-            {
-              "@id": "_:b153",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b154",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with embedded object having properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st16-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st16-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b253",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 9",
-          "assertions": [
-            {
-              "@id": "_:b254",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b255",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st17-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st17-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b189",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 10",
-          "assertions": [
-            {
-              "@id": "_:b188",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b91",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st18-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st18-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b174",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b411",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b412",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st19-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st19-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b166",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b164",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b165",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property multiple values",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st20-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st20-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b429",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 3",
-          "assertions": [
-            {
-              "@id": "_:b430",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b431",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing multiple properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st20a-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st20a-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b493",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 4",
-          "assertions": [
-            {
-              "@id": "_:b492",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b382",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing an empty node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st20b-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st20b-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b362",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 5",
-          "assertions": [
-            {
-              "@id": "_:b363",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b444",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property that is on the top-level is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st21-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b475",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b476",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b477",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on a top-level graph node is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st22-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b370",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b371",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b372",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property having @id is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st23-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b170",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 3",
-          "assertions": [
-            {
-              "@id": "_:b171",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b172",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property with simple value is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st24-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b541",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 4",
-          "assertions": [
-            {
-              "@id": "_:b542",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b536",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property with value object value is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st24a-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b185",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 5",
-          "assertions": [
-            {
-              "@id": "_:b487",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b482",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "@annotation on a list",
-          "mf:result": "invalid set or list object",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st25-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b208",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 6",
-          "assertions": [
-            {
-              "@id": "_:b341",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b342",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation on a list value",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st26-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b270",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 7",
-          "assertions": [
-            {
-              "@id": "_:b271",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b284",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "@annotation property on a top-level @included node is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st27-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b80",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 8",
-          "assertions": [
-            {
-              "@id": "_:b81",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b375",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation that is an embedded node is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st27a-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b77",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 9",
-          "assertions": [
-            {
-              "@id": "_:b78",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b79",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st28-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st28-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b403",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b448",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b419",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st29-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st29-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b441",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b442",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b99",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Embedded node with reverse relationship",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st30-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b307",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 11",
-          "assertions": [
-            {
-              "@id": "_:b305",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b306",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Embedded node with expanded reverse relationship",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st31-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b8",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 12",
-          "assertions": [
-            {
-              "@id": "_:b9",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b10",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Embedded node used as subject in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st32-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st32-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b328",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 13",
-          "assertions": [
-            {
-              "@id": "_:b529",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b160",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "Embedded node used as object in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st33-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st33-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b534",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 14",
-          "assertions": [
-            {
-              "@id": "_:b535",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b538",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st34-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st34-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b30",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b31",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b303",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "reverse relationship inside annotation",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st35-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st35-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b116",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b114",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b115",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "embedded node with an alias of `@id`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st36-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st36-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b239",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for embedded node",
-          "assertions": [
-            {
-              "@id": "_:b240",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b354",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "annotation node with an alias of `@annotation`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st37-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st37-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b222",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for annotation node",
-          "assertions": [
-            {
-              "@id": "_:b545",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b319",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "embedded node with annotation on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st38-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st38-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b74",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation value 1",
-          "assertions": [
-            {
-              "@id": "_:b75",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b76",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "annotation node containing an embedded node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st39-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st39-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b140",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b141",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b142",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest"
-          ],
-          "rdfs:comment": "annotation node containing an annotation node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st40-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st40-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b315",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with annotation 1",
-          "assertions": [
-            {
-              "@id": "_:b316",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b317",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        }
-      ],
-      "title": "Expansion"
-    },
-    {
-      "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest",
-      "@type": [
-        "Report",
-        "mf:Manifest"
-      ],
-      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Compaction Algorithm](https://json-ld.github.io/json-ld-star#compaction-algorithm).",
-      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://json-ld.github.io/json-ld-star/tests/",
-      "entries": [
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having no @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st04-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st04-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st04-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b18",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b19",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b20",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having IRI @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st05-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st05-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st05-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b29",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 2",
-          "assertions": [
-            {
-              "@id": "_:b47",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b355",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having BNode @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st06-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st06-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st06-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b7",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 3",
-          "assertions": [
-            {
-              "@id": "_:b15",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b16",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having a type",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st07-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st07-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st07-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b43",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 4",
-          "assertions": [
-            {
-              "@id": "_:b44",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b296",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an IRI value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st08-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st08-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st08-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b11",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 5",
-          "assertions": [
-            {
-              "@id": "_:b90",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b246",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an BNode value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st09-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st09-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st09-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b0",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 6",
-          "assertions": [
-            {
-              "@id": "_:b1",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b3",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st10-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st10-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st10-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b39",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 7",
-          "assertions": [
-            {
-              "@id": "_:b251",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b269",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st15-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st15-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st15-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b25",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 8",
-          "assertions": [
-            {
-              "@id": "_:b26",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b186",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with embedded object having properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st16-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st16-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st16-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b416",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 9",
-          "assertions": [
-            {
-              "@id": "_:b417",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b418",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st17-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st17-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st17-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b373",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 10",
-          "assertions": [
-            {
-              "@id": "_:b469",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b369",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st18-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st18-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st18-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b250",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b357",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b358",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st19-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st19-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st19-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b50",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b51",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b421",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with @annotation property multiple values",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st20-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st20-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st20-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b32",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 3",
-          "assertions": [
-            {
-              "@id": "_:b33",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b376",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing multiple properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st20a-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st20a-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st20a-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b278",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 4",
-          "assertions": [
-            {
-              "@id": "_:b276",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b277",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing an empty node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st20b-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st20b-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st20b-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b52",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 5",
-          "assertions": [
-            {
-              "@id": "_:b53",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b103",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st28-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st28-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st28-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b518",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b519",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b422",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st29-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st29-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st29-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b491",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b490",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b356",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Embedded node used as subject in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st32-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st32-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st32-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b454",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 13",
-          "assertions": [
-            {
-              "@id": "_:b453",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b89",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "Embedded node used as object in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st33-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st33-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st33-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b461",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 14",
-          "assertions": [
-            {
-              "@id": "_:b462",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b402",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st34-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st34-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st34-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b123",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b124",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b217",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "reverse relationship inside annotation",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st35-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st35-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st35-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b13",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b14",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b180",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "embedded node with an alias of `@id`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st36-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st36-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st36-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b23",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for embedded node",
-          "assertions": [
-            {
-              "@id": "_:b24",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b215",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "annotation node with an alias of `@annotation`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st37-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st37-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st37-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b2",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for annotation node",
-          "assertions": [
-            {
-              "@id": "_:b17",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b374",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "embedded node with annotation on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st38-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st38-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st38-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b242",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation value 1",
-          "assertions": [
-            {
-              "@id": "_:b256",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b439",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "annotation node containing an embedded node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st39-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st39-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st39-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b61",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b62",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b298",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest"
-          ],
-          "rdfs:comment": "annotation node containing an annotation node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st40-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st40-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
-            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st40-out.jsonld"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b247",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with annotation 1",
-          "assertions": [
-            {
-              "@id": "_:b408",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b445",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        }
-      ],
-      "title": "Compaction"
-    },
-    {
-      "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest",
-      "@type": [
-        "Report",
-        "mf:Manifest"
-      ],
-      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Flattening Algorithm](https://json-ld.github.io/json-ld-star#flattening-algorithm).",
-      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://w3c.github.io/json-ld-api/tests/",
-      "entries": [
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node object with @annotation property is ignored without rdfstar option.",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st02-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st02-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b452",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "ignored annotation 1",
-          "assertions": [
-            {
-              "@id": "_:b450",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b451",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Value object with @annotation property is ignored without rdfstar option",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st03-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st03-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b128",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "ignored annotation 2",
-          "assertions": [
-            {
-              "@id": "_:b146",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b520",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having no @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st04-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st04-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b364",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b365",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b539",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having IRI @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st05-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st05-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b262",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 2",
-          "assertions": [
-            {
-              "@id": "_:b263",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b264",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having BNode @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st06-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st06-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b70",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 3",
-          "assertions": [
-            {
-              "@id": "_:b68",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b69",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having a type",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st07-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st07-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b329",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 4",
-          "assertions": [
-            {
-              "@id": "_:b330",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b331",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an IRI value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st08-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st08-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b510",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 5",
-          "assertions": [
-            {
-              "@id": "_:b511",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b516",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an BNode value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st09-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st09-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b48",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 6",
-          "assertions": [
-            {
-              "@id": "_:b49",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b268",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st10-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st10-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b177",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 7",
-          "assertions": [
-            {
-              "@id": "_:b175",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b176",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st15-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st15-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b473",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 8",
-          "assertions": [
-            {
-              "@id": "_:b474",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b275",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with embedded object having properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st16-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st16-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b102",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 9",
-          "assertions": [
-            {
-              "@id": "_:b100",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b101",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st17-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st17-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b285",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 10",
-          "assertions": [
-            {
-              "@id": "_:b286",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b340",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st18-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st18-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b472",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b471",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b201",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st18n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st18-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b420",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 1 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b455",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b456",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st19-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st19-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b348",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b426",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b427",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st19n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st19-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b60",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 2 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b58",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b59",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property multiple values",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b343",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 3",
-          "assertions": [
-            {
-              "@id": "_:b344",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b98",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property multiple values",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b353",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 3 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b351",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b352",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing multiple properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20a-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20a-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b134",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 4",
-          "assertions": [
-            {
-              "@id": "_:b135",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b136",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing multiple properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20an-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20a-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b73",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 4 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b346",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b378",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing an empty node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20b-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20b-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b230",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 5",
-          "assertions": [
-            {
-              "@id": "_:b231",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b339",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing an empty node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20b-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20b-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b282",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 5 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b280",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b281",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st28-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st28-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b207",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b205",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b206",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st28n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st28-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b178",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 1 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b179",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b390",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st29-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st29-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b386",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b387",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b366",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st29n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st29-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b380",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 2 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b381",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b173",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Embedded node used as subject in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st32-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st32-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b156",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 13",
-          "assertions": [
-            {
-              "@id": "_:b157",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b158",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "Embedded node used as object in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st33-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st33-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b435",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 14",
-          "assertions": [
-            {
-              "@id": "_:b436",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b437",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st34-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st34-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b521",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b544",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b499",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st34n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st34-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b148",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 1 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b149",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b150",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "reverse relationship inside annotation",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st35-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st35-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b318",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b522",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b523",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "reverse relationship inside annotation",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st35n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st35-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b35",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 2 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b377",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b310",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "embedded node with an alias of `@id`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st36-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st36-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b212",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for embedded node",
-          "assertions": [
-            {
-              "@id": "_:b213",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b214",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "annotation node with an alias of `@annotation`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st37-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st37-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b218",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for annotation node",
-          "assertions": [
-            {
-              "@id": "_:b497",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b304",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "embedded node with annotation on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st38-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st38-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b204",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation value 1",
-          "assertions": [
-            {
-              "@id": "_:b202",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b203",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "embedded node with annotation on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st38n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st38-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b12",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation value 1 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b384",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b385",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "annotation node containing an embedded node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st39-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st39-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b82",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b83",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b425",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "annotation node containing an embedded node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st39n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st39-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b144",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with embedded node 1 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b145",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b543",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "annotation node containing an annotation node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st40-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st40-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b415",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with annotation 1",
-          "assertions": [
-            {
-              "@id": "_:b413",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b414",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest"
-          ],
-          "rdfs:comment": "annotation node containing an annotation node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st40n-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st40-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b361",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
-            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            }
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with annotation 1 (with @annotation)",
-          "assertions": [
-            {
-              "@id": "_:b540",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b237",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        }
-      ],
-      "title": "Flattening"
-    },
-    {
-      "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest",
-      "@type": [
-        "Report",
-        "mf:Manifest"
-      ],
-      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Serialize RDF as JSON-LD Algorithm](https://json-ld.github.io/json-ld-star#serialize-rdf-as-json-ld-algorithm).",
-      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://w3c.github.io/json-ld-api/tests/",
-      "entries": [
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node object with @annotation property is ignored without rdfstar option.",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st02-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st02-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b163",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "ignored annotation 1",
-          "assertions": [
-            {
-              "@id": "_:b537",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b283",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Value object with @annotation property is ignored without rdfstar option",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st03-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st03-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b57",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "ignored annotation 2",
-          "assertions": [
-            {
-              "@id": "_:b54",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b55",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having no @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st04-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st04-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b349",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b468",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b467",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having IRI @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st05-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st05-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b394",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 2",
-          "assertions": [
-            {
-              "@id": "_:b395",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b527",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having BNode @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st06-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st06-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b289",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 3",
-          "assertions": [
-            {
-              "@id": "_:b287",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b288",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having a type",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st07-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st07-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b97",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 4",
-          "assertions": [
-            {
-              "@id": "_:b96",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b84",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an IRI value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st08-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st08-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b295",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 5",
-          "assertions": [
-            {
-              "@id": "_:b391",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b428",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an BNode value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st09-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st09-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b265",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 6",
-          "assertions": [
-            {
-              "@id": "_:b266",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b267",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st10-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st10-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b200",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 7",
-          "assertions": [
-            {
-              "@id": "_:b198",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b199",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st15-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st15-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b501",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 8",
-          "assertions": [
-            {
-              "@id": "_:b502",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b503",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with embedded object having properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st16-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st16-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b478",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 9",
-          "assertions": [
-            {
-              "@id": "_:b479",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b498",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st17-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st17-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b45",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 10",
-          "assertions": [
-            {
-              "@id": "_:b46",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b379",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st18-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st18-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b161",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b162",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b401",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st19-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st19-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b167",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b168",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b169",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with @annotation property multiple values",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b360",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 3",
-          "assertions": [
-            {
-              "@id": "_:b359",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b245",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing multiple properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20a-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20a-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b406",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 4",
-          "assertions": [
-            {
-              "@id": "_:b407",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b509",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing an empty node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20b-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20b-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b309",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 5",
-          "assertions": [
-            {
-              "@id": "_:b321",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b383",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st28-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st28-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b399",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b400",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b120",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st29-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st29-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b21",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b22",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b279",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Embedded node used as subject in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st32-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st32-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b290",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 13",
-          "assertions": [
-            {
-              "@id": "_:b533",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b532",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "Embedded node used as object in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st33-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st33-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b409",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 14",
-          "assertions": [
-            {
-              "@id": "_:b410",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b440",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st34-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st34-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b338",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b336",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b337",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "reverse relationship inside annotation",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st35-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st35-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b459",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b460",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b107",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "embedded node with an alias of `@id`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st36-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st36-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b311",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for embedded node",
-          "assertions": [
-            {
-              "@id": "_:b312",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b320",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "annotation node with an alias of `@annotation`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st37-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st37-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b292",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for annotation node",
-          "assertions": [
-            {
-              "@id": "_:b293",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b294",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "embedded node with annotation on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st38-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st38-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b243",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation value 1",
-          "assertions": [
-            {
-              "@id": "_:b244",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b347",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "annotation node containing an embedded node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st39-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st39-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b325",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b326",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b327",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest"
-          ],
-          "rdfs:comment": "annotation node containing an annotation node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st40-out.jsonld",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st40-in.nq",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b147",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with annotation 1",
-          "assertions": [
-            {
-              "@id": "_:b181",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b182",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        }
-      ],
-      "title": "Transform RDF to JSON-LD"
-    },
-    {
-      "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest",
-      "@type": [
-        "Report",
-        "mf:Manifest"
-      ],
-      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Deserialize JSON-LD to RDF Algorithm](https://json-ld.github.io/json-ld-star#deserialize-json-ld-to-rdf-algorithm).",
-      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://w3c.github.io/json-ld-api/tests/",
-      "entries": [
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Node with embedded subject without rdfstar option.",
-          "mf:result": "invalid @id value",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st01-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b528",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b546",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b314",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node object with @annotation property is ignored without rdfstar option.",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st02-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st02-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b225",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "ignored annotation 1",
-          "assertions": [
-            {
-              "@id": "_:b226",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b470",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Value object with @annotation property is ignored without rdfstar option",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st03-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st03-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b92",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "false"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "ignored annotation 2",
-          "assertions": [
-            {
-              "@id": "_:b93",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b184",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having no @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st04-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st04-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b137",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b138",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b139",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having IRI @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st05-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st05-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b434",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 2",
-          "assertions": [
-            {
-              "@id": "_:b432",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b433",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having BNode @id",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st06-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st06-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b465",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 3",
-          "assertions": [
-            {
-              "@id": "_:b463",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b464",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having a type",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st07-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st07-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b438",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 4",
-          "assertions": [
-            {
-              "@id": "_:b524",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b525",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an IRI value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st08-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st08-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b190",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 5",
-          "assertions": [
-            {
-              "@id": "_:b191",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b526",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with embedded subject having an BNode value",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st09-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st09-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b495",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 6",
-          "assertions": [
-            {
-              "@id": "_:b494",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b232",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st10-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st10-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b368",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 7",
-          "assertions": [
-            {
-              "@id": "_:b367",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b133",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Illegal node with subject having no property",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st11-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b392",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 2",
-          "assertions": [
-            {
-              "@id": "_:b393",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b446",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Illegal node with subject having multiple properties",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st12-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b259",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 3",
-          "assertions": [
-            {
-              "@id": "_:b257",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b258",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Illegal node with subject having multiple types",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st13-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b423",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 4",
-          "assertions": [
-            {
-              "@id": "_:b424",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b345",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Illegal node with subject having type and property",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st14-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b260",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "invalid embedded node 5",
-          "assertions": [
-            {
-              "@id": "_:b261",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b143",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st15-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st15-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b121",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 8",
-          "assertions": [
-            {
-              "@id": "_:b122",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b95",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with embedded object having properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st16-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st16-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b195",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 9",
-          "assertions": [
-            {
-              "@id": "_:b196",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b197",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with recursive embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st17-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st17-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b36",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 10",
-          "assertions": [
-            {
-              "@id": "_:b37",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b38",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st18-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st18-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b500",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b507",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b483",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st19-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st19-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b227",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b228",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b229",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property multiple values",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b211",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 3",
-          "assertions": [
-            {
-              "@id": "_:b513",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b514",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing multiple properties",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20a-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20a-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b235",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 4",
-          "assertions": [
-            {
-              "@id": "_:b236",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b517",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property containing an empty node object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20b-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20b-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b88",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Annotation node 5",
-          "assertions": [
-            {
-              "@id": "_:b252",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b216",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property that is on the top-level is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st21-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b113",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b111",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b112",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on a top-level graph node is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st22-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b117",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b118",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b447",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property having @id is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st23-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b238",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 3",
-          "assertions": [
-            {
-              "@id": "_:b297",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b313",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property with simple value is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st24-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b104",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 4",
-          "assertions": [
-            {
-              "@id": "_:b105",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b106",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property with value object value is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st24a-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b398",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 5",
-          "assertions": [
-            {
-              "@id": "_:b396",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b397",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "@annotation on a list",
-          "mf:result": "invalid set or list object",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st25-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b274",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 6",
-          "assertions": [
-            {
-              "@id": "_:b272",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b273",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation on a list value",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st26-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b388",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 7",
-          "assertions": [
-            {
-              "@id": "_:b389",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b496",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "@annotation property on a top-level @included node is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st27-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b488",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 8",
-          "assertions": [
-            {
-              "@id": "_:b489",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b151",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation that is an embedded node is invalid",
-          "mf:result": "invalid annotation",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st27a-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b223",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Invalid annotation node 9",
-          "assertions": [
-            {
-              "@id": "_:b224",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b183",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded subject",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st28-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st28-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b484",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b485",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b486",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Node with @annotation property on embedded object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st29-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st29-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b125",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Embedded annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b126",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b127",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Embedded node with reverse relationship",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st30-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b87",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 11",
-          "assertions": [
-            {
-              "@id": "_:b85",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b86",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest"
-          ],
-          "rdfs:comment": "Embedded node with expanded reverse relationship",
-          "mf:result": "invalid embedded node",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st31-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b63",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 12",
-          "assertions": [
-            {
-              "@id": "_:b64",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b65",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Embedded node used as subject in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st32-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st32-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b457",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 13",
-          "assertions": [
-            {
-              "@id": "_:b458",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b449",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "Embedded node used as object in reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st33-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st33-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b481",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "embedded node 14",
-          "assertions": [
-            {
-              "@id": "_:b480",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b308",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st34-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st34-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b291",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 1",
-          "assertions": [
-            {
-              "@id": "_:b301",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b302",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "reverse relationship inside annotation",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st35-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st35-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b209",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Reverse annotation node 2",
-          "assertions": [
-            {
-              "@id": "_:b210",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b187",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "embedded node with an alias of `@id`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st36-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st36-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b299",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for embedded node",
-          "assertions": [
-            {
-              "@id": "_:b300",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b508",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "annotation node with an alias of `@annotation`",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st37-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st37-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b332",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "Alias for annotation node",
-          "assertions": [
-            {
-              "@id": "_:b333",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b350",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "embedded node with annotation on value object",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st38-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st38-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b110",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation value 1",
-          "assertions": [
-            {
-              "@id": "_:b108",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b109",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "annotation node containing an embedded node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st39-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st39-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b34",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with embedded node 1",
-          "assertions": [
-            {
-              "@id": "_:b119",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b443",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        },
-        {
-          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40",
-          "@type": [
-            "TestCriterion",
-            "TestCase",
-            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
-            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
-          ],
-          "rdfs:comment": "annotation node containing an annotation node",
-          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st40-out.nq",
-          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st40-in.jsonld",
-          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
-            "@id": "_:b335",
-            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
-              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-              "@value": "true"
-            },
-            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
-          },
-          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
-          "title": "annotation with annotation 1",
-          "assertions": [
-            {
-              "@id": "_:b334",
-              "@type": "Assertion",
-              "subject": "https://rubygems.org/gems/json-ld",
-              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40",
-              "assertedBy": "http://greggkellogg.net/foaf#me",
-              "mode": "earl:automatic",
-              "result": {
-                "@id": "_:b233",
-                "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
-            }
-          ]
-        }
-      ],
-      "title": "Transform JSON-LD to RDF"
-    }
   ],
   "name": "JSON-LD*",
   "generatedBy": {
     "@id": "https://rubygems.org/gems/earl-report",
     "@type": [
-      "Software",
-      "doap:Project"
+      "doap:Project",
+      "Software"
     ],
     "license": "http://unlicense.org",
     "homepage": "https://github.com/gkellogg/earl-report",
-    "developer": [
-      "http://greggkellogg.net/foaf#me"
-    ],
+    "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
     "shortdesc": "Earl Report summary generator",
+    "name": "earl-report",
     "release": {
       "@id": "https://github.com/gkellogg/earl-report/tree/0.5.2",
       "@type": "doap:Version",
@@ -7081,8 +157,6932 @@
       },
       "name": "earl-report-0.5.2"
     },
-    "name": "earl-report",
-    "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
-    "language": "Ruby"
-  }
+    "language": "Ruby",
+    "developer": [
+      "http://greggkellogg.net/foaf#me"
+    ]
+  },
+  "entries": [
+    {
+      "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Serialize RDF as JSON-LD Algorithm](https://json-ld.github.io/json-ld-star#serialize-rdf-as-json-ld-algorithm).",
+      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://w3c.github.io/json-ld-api/tests/",
+      "title": "Transform RDF to JSON-LD",
+      "entries": [
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node object with @annotation property is ignored without rdfstar option.",
+          "assertions": [
+            {
+              "@id": "_:b235",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02",
+              "result": {
+                "@id": "_:b236",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st02-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st02-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "ignored annotation 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b237",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Value object with @annotation property is ignored without rdfstar option",
+          "assertions": [
+            {
+              "@id": "_:b450",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03",
+              "result": {
+                "@id": "_:b311",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st03-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st03-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "ignored annotation 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b424",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having no @id",
+          "assertions": [
+            {
+              "@id": "_:b105",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04",
+              "result": {
+                "@id": "_:b107",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st04-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st04-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b106",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having IRI @id",
+          "assertions": [
+            {
+              "@id": "_:b350",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05",
+              "result": {
+                "@id": "_:b501",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st05-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st05-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b256",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having BNode @id",
+          "assertions": [
+            {
+              "@id": "_:b254",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06",
+              "result": {
+                "@id": "_:b478",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st06-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st06-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b255",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having a type",
+          "assertions": [
+            {
+              "@id": "_:b90",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07",
+              "result": {
+                "@id": "_:b144",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st07-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st07-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b91",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having an IRI value",
+          "assertions": [
+            {
+              "@id": "_:b0",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08",
+              "result": {
+                "@id": "_:b2",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st08-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st08-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b1",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having an BNode value",
+          "assertions": [
+            {
+              "@id": "_:b203",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09",
+              "result": {
+                "@id": "_:b204",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st09-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st09-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 6",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b180",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with recursive embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b503",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10",
+              "result": {
+                "@id": "_:b447",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st10-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st10-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 7",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b265",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded object",
+          "assertions": [
+            {
+              "@id": "_:b160",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15",
+              "result": {
+                "@id": "_:b162",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st15-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st15-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 8",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b161",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded object having properties",
+          "assertions": [
+            {
+              "@id": "_:b277",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16",
+              "result": {
+                "@id": "_:b278",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st16-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st16-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 9",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b279",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with recursive embedded object",
+          "assertions": [
+            {
+              "@id": "_:b343",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17",
+              "result": {
+                "@id": "_:b145",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st17-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st17-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 10",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b296",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on value object",
+          "assertions": [
+            {
+              "@id": "_:b468",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18",
+              "result": {
+                "@id": "_:b261",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st18-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st18-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b469",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on node object",
+          "assertions": [
+            {
+              "@id": "_:b520",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19",
+              "result": {
+                "@id": "_:b344",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st19-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st19-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b521",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property multiple values",
+          "assertions": [
+            {
+              "@id": "_:b473",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20",
+              "result": {
+                "@id": "_:b250",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b474",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing multiple properties",
+          "assertions": [
+            {
+              "@id": "_:b149",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a",
+              "result": {
+                "@id": "_:b367",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20a-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20a-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b150",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing an empty node object",
+          "assertions": [
+            {
+              "@id": "_:b80",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b",
+              "result": {
+                "@id": "_:b82",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20b-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st20b-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b81",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b26",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28",
+              "result": {
+                "@id": "_:b28",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st28-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st28-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b27",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded object",
+          "assertions": [
+            {
+              "@id": "_:b84",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29",
+              "result": {
+                "@id": "_:b85",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st29-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st29-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b86",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node used as subject in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b190",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32",
+              "result": {
+                "@id": "_:b125",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st32-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st32-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 13",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b64",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node used as object in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b120",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33",
+              "result": {
+                "@id": "_:b122",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st33-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st33-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 14",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b121",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b258",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34",
+              "result": {
+                "@id": "_:b288",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st34-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st34-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b199",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "reverse relationship inside annotation",
+          "assertions": [
+            {
+              "@id": "_:b531",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35",
+              "result": {
+                "@id": "_:b532",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st35-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st35-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b274",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "embedded node with an alias of `@id`",
+          "assertions": [
+            {
+              "@id": "_:b129",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36",
+              "result": {
+                "@id": "_:b384",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st36-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st36-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b130",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node with an alias of `@annotation`",
+          "assertions": [
+            {
+              "@id": "_:b351",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37",
+              "result": {
+                "@id": "_:b352",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st37-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st37-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for annotation node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b273",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "embedded node with annotation on value object",
+          "assertions": [
+            {
+              "@id": "_:b515",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38",
+              "result": {
+                "@id": "_:b516",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st38-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st38-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation value 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b65",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an embedded node",
+          "assertions": [
+            {
+              "@id": "_:b481",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39",
+              "result": {
+                "@id": "_:b483",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st39-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st39-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b482",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an annotation node",
+          "assertions": [
+            {
+              "@id": "_:b322",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40",
+              "result": {
+                "@id": "_:b477",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st40-in.nq",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/fromRdf/st40-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with annotation 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b323",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Expansion Algorithm](https://json-ld.github.io/json-ld-star#expansion-algorithm).",
+      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://w3c.github.io/json-ld-api/tests/",
+      "title": "Expansion",
+      "entries": [
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with embedded subject without rdfstar option.",
+          "assertions": [
+            {
+              "@id": "_:b403",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01",
+              "result": {
+                "@id": "_:b405",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st01-in.jsonld",
+          "mf:result": "invalid @id value",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b404",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node object with @annotation property is ignored without rdfstar option.",
+          "assertions": [
+            {
+              "@id": "_:b470",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02",
+              "result": {
+                "@id": "_:b471",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st02-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st02-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "ignored annotation 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b126",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Value object with @annotation property is ignored without rdfstar option",
+          "assertions": [
+            {
+              "@id": "_:b176",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03",
+              "result": {
+                "@id": "_:b178",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st03-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st03-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "ignored annotation 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b177",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with embedded subject having no @id",
+          "assertions": [
+            {
+              "@id": "_:b201",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04",
+              "result": {
+                "@id": "_:b369",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st04-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st04-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b202",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with embedded subject having IRI @id",
+          "assertions": [
+            {
+              "@id": "_:b416",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05",
+              "result": {
+                "@id": "_:b418",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st05-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st05-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b417",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with embedded subject having BNode @id",
+          "assertions": [
+            {
+              "@id": "_:b523",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06",
+              "result": {
+                "@id": "_:b166",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st06-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st06-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b492",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with embedded subject having a type",
+          "assertions": [
+            {
+              "@id": "_:b430",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07",
+              "result": {
+                "@id": "_:b119",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st07-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st07-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b348",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with embedded subject having an IRI value",
+          "assertions": [
+            {
+              "@id": "_:b297",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08",
+              "result": {
+                "@id": "_:b108",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st08-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st08-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b243",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with embedded subject having an BNode value",
+          "assertions": [
+            {
+              "@id": "_:b341",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09",
+              "result": {
+                "@id": "_:b289",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st09-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st09-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 6",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b109",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with recursive embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b271",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10",
+              "result": {
+                "@id": "_:b272",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st10-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st10-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 7",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b19",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Illegal node with subject having no property",
+          "assertions": [
+            {
+              "@id": "_:b370",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11",
+              "result": {
+                "@id": "_:b526",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st11-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b318",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Illegal node with subject having multiple properties",
+          "assertions": [
+            {
+              "@id": "_:b259",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12",
+              "result": {
+                "@id": "_:b260",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st12-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b63",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Illegal node with subject having multiple types",
+          "assertions": [
+            {
+              "@id": "_:b100",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13",
+              "result": {
+                "@id": "_:b545",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st13-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b101",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Illegal node with subject having type and property",
+          "assertions": [
+            {
+              "@id": "_:b332",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14",
+              "result": {
+                "@id": "_:b457",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st14-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b333",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with embedded object",
+          "assertions": [
+            {
+              "@id": "_:b15",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15",
+              "result": {
+                "@id": "_:b134",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st15-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st15-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 8",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b16",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with embedded object having properties",
+          "assertions": [
+            {
+              "@id": "_:b5",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16",
+              "result": {
+                "@id": "_:b7",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st16-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st16-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 9",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b6",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with recursive embedded object",
+          "assertions": [
+            {
+              "@id": "_:b451",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17",
+              "result": {
+                "@id": "_:b452",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st17-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st17-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 10",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b453",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property on value object",
+          "assertions": [
+            {
+              "@id": "_:b522",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18",
+              "result": {
+                "@id": "_:b146",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st18-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st18-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b518",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property on node object",
+          "assertions": [
+            {
+              "@id": "_:b171",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19",
+              "result": {
+                "@id": "_:b172",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st19-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st19-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b173",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property multiple values",
+          "assertions": [
+            {
+              "@id": "_:b52",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20",
+              "result": {
+                "@id": "_:b54",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st20-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st20-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b53",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property containing multiple properties",
+          "assertions": [
+            {
+              "@id": "_:b463",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a",
+              "result": {
+                "@id": "_:b275",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st20a-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st20a-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b464",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property containing an empty node object",
+          "assertions": [
+            {
+              "@id": "_:b399",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b",
+              "result": {
+                "@id": "_:b401",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st20b-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st20b-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b400",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property that is on the top-level is invalid",
+          "assertions": [
+            {
+              "@id": "_:b496",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21",
+              "result": {
+                "@id": "_:b493",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st21-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b497",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property on a top-level graph node is invalid",
+          "assertions": [
+            {
+              "@id": "_:b163",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22",
+              "result": {
+                "@id": "_:b336",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st22-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b164",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property having @id is invalid",
+          "assertions": [
+            {
+              "@id": "_:b251",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23",
+              "result": {
+                "@id": "_:b252",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st23-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b253",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property with simple value is invalid",
+          "assertions": [
+            {
+              "@id": "_:b66",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24",
+              "result": {
+                "@id": "_:b68",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st24-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b67",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property with value object value is invalid",
+          "assertions": [
+            {
+              "@id": "_:b92",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a",
+              "result": {
+                "@id": "_:b94",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st24a-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b93",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "@annotation on a list",
+          "assertions": [
+            {
+              "@id": "_:b381",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25",
+              "result": {
+                "@id": "_:b87",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st25-in.jsonld",
+          "mf:result": "invalid set or list object",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 6",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b382",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation on a list value",
+          "assertions": [
+            {
+              "@id": "_:b263",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26",
+              "result": {
+                "@id": "_:b95",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st26-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 7",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b264",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "@annotation property on a top-level @included node is invalid",
+          "assertions": [
+            {
+              "@id": "_:b383",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27",
+              "result": {
+                "@id": "_:b500",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st27-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 8",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b321",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation that is an embedded node is invalid",
+          "assertions": [
+            {
+              "@id": "_:b487",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a",
+              "result": {
+                "@id": "_:b489",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st27a-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 9",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b488",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b357",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28",
+              "result": {
+                "@id": "_:b423",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st28-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st28-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b358",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded object",
+          "assertions": [
+            {
+              "@id": "_:b241",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29",
+              "result": {
+                "@id": "_:b420",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st29-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st29-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b242",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Embedded node with reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b302",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30",
+              "result": {
+                "@id": "_:b303",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st30-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 11",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b304",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Embedded node with expanded reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b110",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31",
+              "result": {
+                "@id": "_:b353",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st31-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 12",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b111",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Embedded node used as subject in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b37",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32",
+              "result": {
+                "@id": "_:b39",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st32-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st32-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 13",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b38",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "Embedded node used as object in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b112",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33",
+              "result": {
+                "@id": "_:b301",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st33-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st33-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 14",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b113",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b371",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34",
+              "result": {
+                "@id": "_:b372",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st34-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st34-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b373",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "reverse relationship inside annotation",
+          "assertions": [
+            {
+              "@id": "_:b378",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35",
+              "result": {
+                "@id": "_:b379",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st35-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st35-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b374",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "embedded node with an alias of `@id`",
+          "assertions": [
+            {
+              "@id": "_:b445",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36",
+              "result": {
+                "@id": "_:b281",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st36-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st36-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b446",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "annotation node with an alias of `@annotation`",
+          "assertions": [
+            {
+              "@id": "_:b460",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37",
+              "result": {
+                "@id": "_:b461",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st37-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st37-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for annotation node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b462",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "embedded node with annotation on value object",
+          "assertions": [
+            {
+              "@id": "_:b407",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38",
+              "result": {
+                "@id": "_:b502",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st38-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st38-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation value 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b402",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "annotation node containing an embedded node",
+          "assertions": [
+            {
+              "@id": "_:b527",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39",
+              "result": {
+                "@id": "_:b499",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st39-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st39-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b528",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "rdfs:comment": "annotation node containing an annotation node",
+          "assertions": [
+            {
+              "@id": "_:b168",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40",
+              "result": {
+                "@id": "_:b169",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/expand/st40-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/expand/st40-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with annotation 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b170",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Flattening Algorithm](https://json-ld.github.io/json-ld-star#flattening-algorithm).",
+      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://w3c.github.io/json-ld-api/tests/",
+      "title": "Flattening",
+      "entries": [
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node object with @annotation property is ignored without rdfstar option.",
+          "assertions": [
+            {
+              "@id": "_:b359",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02",
+              "result": {
+                "@id": "_:b505",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st02-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st02-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "ignored annotation 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b360",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Value object with @annotation property is ignored without rdfstar option",
+          "assertions": [
+            {
+              "@id": "_:b135",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03",
+              "result": {
+                "@id": "_:b136",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st03-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st03-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "ignored annotation 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b137",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having no @id",
+          "assertions": [
+            {
+              "@id": "_:b504",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04",
+              "result": {
+                "@id": "_:b270",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st04-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st04-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b280",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having IRI @id",
+          "assertions": [
+            {
+              "@id": "_:b465",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05",
+              "result": {
+                "@id": "_:b467",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st05-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st05-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b466",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having BNode @id",
+          "assertions": [
+            {
+              "@id": "_:b114",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06",
+              "result": {
+                "@id": "_:b186",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st06-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st06-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b115",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having a type",
+          "assertions": [
+            {
+              "@id": "_:b454",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07",
+              "result": {
+                "@id": "_:b456",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st07-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st07-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b455",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having an IRI value",
+          "assertions": [
+            {
+              "@id": "_:b17",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08",
+              "result": {
+                "@id": "_:b312",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st08-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st08-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b18",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having an BNode value",
+          "assertions": [
+            {
+              "@id": "_:b310",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09",
+              "result": {
+                "@id": "_:b207",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st09-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st09-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 6",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b104",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with recursive embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b294",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10",
+              "result": {
+                "@id": "_:b167",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st10-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st10-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 7",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b295",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded object",
+          "assertions": [
+            {
+              "@id": "_:b225",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15",
+              "result": {
+                "@id": "_:b226",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st15-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st15-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 8",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b227",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded object having properties",
+          "assertions": [
+            {
+              "@id": "_:b511",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16",
+              "result": {
+                "@id": "_:b439",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st16-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st16-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 9",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b484",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with recursive embedded object",
+          "assertions": [
+            {
+              "@id": "_:b123",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17",
+              "result": {
+                "@id": "_:b313",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st17-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st17-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 10",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b124",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on value object",
+          "assertions": [
+            {
+              "@id": "_:b538",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18",
+              "result": {
+                "@id": "_:b355",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st18-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st18-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b539",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on value object",
+          "assertions": [
+            {
+              "@id": "_:b512",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n",
+              "result": {
+                "@id": "_:b195",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st18-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st18n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 1 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b191",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on node object",
+          "assertions": [
+            {
+              "@id": "_:b187",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19",
+              "result": {
+                "@id": "_:b188",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st19-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st19-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b189",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on node object",
+          "assertions": [
+            {
+              "@id": "_:b388",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n",
+              "result": {
+                "@id": "_:b390",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st19-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st19n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 2 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b389",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property multiple values",
+          "assertions": [
+            {
+              "@id": "_:b72",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20",
+              "result": {
+                "@id": "_:b73",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b75",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property multiple values",
+          "assertions": [
+            {
+              "@id": "_:b290",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n",
+              "result": {
+                "@id": "_:b70",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 3 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b291",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing multiple properties",
+          "assertions": [
+            {
+              "@id": "_:b443",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a",
+              "result": {
+                "@id": "_:b444",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20a-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20a-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b392",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing multiple properties",
+          "assertions": [
+            {
+              "@id": "_:b285",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an",
+              "result": {
+                "@id": "_:b287",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20a-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20an-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 4 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b286",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing an empty node object",
+          "assertions": [
+            {
+              "@id": "_:b141",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b",
+              "result": {
+                "@id": "_:b143",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20b-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20b-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b142",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing an empty node object",
+          "assertions": [
+            {
+              "@id": "_:b506",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn",
+              "result": {
+                "@id": "_:b298",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st20b-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st20b-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 5 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b356",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b230",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28",
+              "result": {
+                "@id": "_:b491",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st28-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st28-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b231",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b308",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n",
+              "result": {
+                "@id": "_:b517",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st28-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st28n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 1 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b309",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded object",
+          "assertions": [
+            {
+              "@id": "_:b519",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29",
+              "result": {
+                "@id": "_:b257",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st29-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st29-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b206",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded object",
+          "assertions": [
+            {
+              "@id": "_:b228",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n",
+              "result": {
+                "@id": "_:b248",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st29-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st29n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 2 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b229",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node used as subject in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b408",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32",
+              "result": {
+                "@id": "_:b220",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st32-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st32-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 13",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b216",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node used as object in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b329",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33",
+              "result": {
+                "@id": "_:b330",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st33-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st33-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 14",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b331",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b345",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34",
+              "result": {
+                "@id": "_:b346",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st34-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st34-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b347",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b131",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n",
+              "result": {
+                "@id": "_:b132",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st34-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st34n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 1 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b50",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "reverse relationship inside annotation",
+          "assertions": [
+            {
+              "@id": "_:b211",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35",
+              "result": {
+                "@id": "_:b213",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st35-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st35-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b212",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "reverse relationship inside annotation",
+          "assertions": [
+            {
+              "@id": "_:b432",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n",
+              "result": {
+                "@id": "_:b433",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st35-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st35n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 2 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b434",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "embedded node with an alias of `@id`",
+          "assertions": [
+            {
+              "@id": "_:b354",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36",
+              "result": {
+                "@id": "_:b340",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st36-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st36-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b200",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node with an alias of `@annotation`",
+          "assertions": [
+            {
+              "@id": "_:b409",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37",
+              "result": {
+                "@id": "_:b339",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st37-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st37-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for annotation node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b410",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "embedded node with annotation on value object",
+          "assertions": [
+            {
+              "@id": "_:b537",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38",
+              "result": {
+                "@id": "_:b533",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st38-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st38-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation value 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b76",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "embedded node with annotation on value object",
+          "assertions": [
+            {
+              "@id": "_:b314",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n",
+              "result": {
+                "@id": "_:b366",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st38-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st38n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation value 1 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b315",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an embedded node",
+          "assertions": [
+            {
+              "@id": "_:b245",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39",
+              "result": {
+                "@id": "_:b246",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st39-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st39-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b247",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an embedded node",
+          "assertions": [
+            {
+              "@id": "_:b326",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n",
+              "result": {
+                "@id": "_:b328",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st39-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st39n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with embedded node 1 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b327",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an annotation node",
+          "assertions": [
+            {
+              "@id": "_:b214",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40",
+              "result": {
+                "@id": "_:b210",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st40-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st40-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with annotation 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b215",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an annotation node",
+          "assertions": [
+            {
+              "@id": "_:b158",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n",
+              "result": {
+                "@id": "_:b205",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/flatten/st40-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/flatten/st40n-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with annotation 1 (with @annotation)",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b159",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*",
+            "https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Deserialize JSON-LD to RDF Algorithm](https://json-ld.github.io/json-ld-star#deserialize-json-ld-to-rdf-algorithm).",
+      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://w3c.github.io/json-ld-api/tests/",
+      "title": "Transform JSON-LD to RDF",
+      "entries": [
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject without rdfstar option.",
+          "assertions": [
+            {
+              "@id": "_:b334",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01",
+              "result": {
+                "@id": "_:b535",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st01-in.jsonld",
+          "mf:result": "invalid @id value",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b335",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node object with @annotation property is ignored without rdfstar option.",
+          "assertions": [
+            {
+              "@id": "_:b96",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02",
+              "result": {
+                "@id": "_:b97",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st02-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st02-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "ignored annotation 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b98",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Value object with @annotation property is ignored without rdfstar option",
+          "assertions": [
+            {
+              "@id": "_:b411",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03",
+              "result": {
+                "@id": "_:b127",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st03-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st03-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "ignored annotation 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b412",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "false"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having no @id",
+          "assertions": [
+            {
+              "@id": "_:b375",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04",
+              "result": {
+                "@id": "_:b536",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st04-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st04-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b368",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having IRI @id",
+          "assertions": [
+            {
+              "@id": "_:b223",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05",
+              "result": {
+                "@id": "_:b435",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st05-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st05-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b224",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having BNode @id",
+          "assertions": [
+            {
+              "@id": "_:b147",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06",
+              "result": {
+                "@id": "_:b317",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st06-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st06-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b148",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having a type",
+          "assertions": [
+            {
+              "@id": "_:b479",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07",
+              "result": {
+                "@id": "_:b480",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st07-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st07-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b244",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having an IRI value",
+          "assertions": [
+            {
+              "@id": "_:b427",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08",
+              "result": {
+                "@id": "_:b429",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st08-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st08-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b428",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having an BNode value",
+          "assertions": [
+            {
+              "@id": "_:b342",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09",
+              "result": {
+                "@id": "_:b393",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st09-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st09-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 6",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b165",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with recursive embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b151",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10",
+              "result": {
+                "@id": "_:b152",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st10-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st10-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 7",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b153",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Illegal node with subject having no property",
+          "assertions": [
+            {
+              "@id": "_:b458",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11",
+              "result": {
+                "@id": "_:b459",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st11-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b307",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Illegal node with subject having multiple properties",
+          "assertions": [
+            {
+              "@id": "_:b413",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12",
+              "result": {
+                "@id": "_:b415",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st12-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b414",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Illegal node with subject having multiple types",
+          "assertions": [
+            {
+              "@id": "_:b174",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13",
+              "result": {
+                "@id": "_:b249",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st13-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b175",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Illegal node with subject having type and property",
+          "assertions": [
+            {
+              "@id": "_:b155",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14",
+              "result": {
+                "@id": "_:b157",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st14-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "invalid embedded node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b156",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded object",
+          "assertions": [
+            {
+              "@id": "_:b508",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15",
+              "result": {
+                "@id": "_:b509",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st15-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st15-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 8",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b77",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded object having properties",
+          "assertions": [
+            {
+              "@id": "_:b529",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16",
+              "result": {
+                "@id": "_:b513",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st16-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st16-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 9",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b530",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with recursive embedded object",
+          "assertions": [
+            {
+              "@id": "_:b276",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17",
+              "result": {
+                "@id": "_:b406",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st17-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st17-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 10",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b232",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on value object",
+          "assertions": [
+            {
+              "@id": "_:b510",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18",
+              "result": {
+                "@id": "_:b543",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st18-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st18-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b448",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on node object",
+          "assertions": [
+            {
+              "@id": "_:b361",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19",
+              "result": {
+                "@id": "_:b363",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st19-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st19-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b362",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property multiple values",
+          "assertions": [
+            {
+              "@id": "_:b440",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20",
+              "result": {
+                "@id": "_:b442",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b441",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing multiple properties",
+          "assertions": [
+            {
+              "@id": "_:b394",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a",
+              "result": {
+                "@id": "_:b498",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20a-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20a-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b395",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing an empty node object",
+          "assertions": [
+            {
+              "@id": "_:b292",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b",
+              "result": {
+                "@id": "_:b475",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20b-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st20b-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b293",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property that is on the top-level is invalid",
+          "assertions": [
+            {
+              "@id": "_:b181",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21",
+              "result": {
+                "@id": "_:b514",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st21-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b182",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on a top-level graph node is invalid",
+          "assertions": [
+            {
+              "@id": "_:b233",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22",
+              "result": {
+                "@id": "_:b494",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st22-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b234",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property having @id is invalid",
+          "assertions": [
+            {
+              "@id": "_:b421",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23",
+              "result": {
+                "@id": "_:b490",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st23-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b422",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property with simple value is invalid",
+          "assertions": [
+            {
+              "@id": "_:b540",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24",
+              "result": {
+                "@id": "_:b485",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st24-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b194",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property with value object value is invalid",
+          "assertions": [
+            {
+              "@id": "_:b364",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a",
+              "result": {
+                "@id": "_:b316",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st24a-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b365",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "@annotation on a list",
+          "assertions": [
+            {
+              "@id": "_:b218",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25",
+              "result": {
+                "@id": "_:b71",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st25-in.jsonld",
+          "mf:result": "invalid set or list object",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 6",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b219",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation on a list value",
+          "assertions": [
+            {
+              "@id": "_:b31",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26",
+              "result": {
+                "@id": "_:b33",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st26-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 7",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b32",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "@annotation property on a top-level @included node is invalid",
+          "assertions": [
+            {
+              "@id": "_:b376",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27",
+              "result": {
+                "@id": "_:b128",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st27-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 8",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b377",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation that is an embedded node is invalid",
+          "assertions": [
+            {
+              "@id": "_:b238",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a",
+              "result": {
+                "@id": "_:b240",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st27a-in.jsonld",
+          "mf:result": "invalid annotation",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Invalid annotation node 9",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b239",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b324",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28",
+              "result": {
+                "@id": "_:b391",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st28-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st28-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b325",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded object",
+          "assertions": [
+            {
+              "@id": "_:b196",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29",
+              "result": {
+                "@id": "_:b197",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st29-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st29-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b198",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node with reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b319",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30",
+              "result": {
+                "@id": "_:b544",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st30-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 11",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b320",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node with expanded reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b385",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31",
+              "result": {
+                "@id": "_:b387",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st31-in.jsonld",
+          "mf:result": "invalid embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 12",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b386",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node used as subject in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b524",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32",
+              "result": {
+                "@id": "_:b525",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st32-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st32-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 13",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b30",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node used as object in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b192",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33",
+              "result": {
+                "@id": "_:b193",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st33-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st33-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 14",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b154",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b282",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34",
+              "result": {
+                "@id": "_:b284",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st34-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st34-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b283",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "reverse relationship inside annotation",
+          "assertions": [
+            {
+              "@id": "_:b305",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35",
+              "result": {
+                "@id": "_:b306",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st35-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st35-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b83",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "embedded node with an alias of `@id`",
+          "assertions": [
+            {
+              "@id": "_:b266",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36",
+              "result": {
+                "@id": "_:b268",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st36-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st36-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b267",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node with an alias of `@annotation`",
+          "assertions": [
+            {
+              "@id": "_:b337",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37",
+              "result": {
+                "@id": "_:b338",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st37-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st37-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for annotation node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b300",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "embedded node with annotation on value object",
+          "assertions": [
+            {
+              "@id": "_:b221",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38",
+              "result": {
+                "@id": "_:b99",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st38-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st38-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation value 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b222",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an embedded node",
+          "assertions": [
+            {
+              "@id": "_:b138",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39",
+              "result": {
+                "@id": "_:b140",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st39-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st39-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b139",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an annotation node",
+          "assertions": [
+            {
+              "@id": "_:b78",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40",
+              "result": {
+                "@id": "_:b79",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/toRdf/st40-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/toRdf/st40-out.nq",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with annotation 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b69",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          }
+        }
+      ]
+    },
+    {
+      "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:comment": "These tests implement the requirements for the JSON-LD* [Compaction Algorithm](https://json-ld.github.io/json-ld-star#compaction-algorithm).",
+      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://json-ld.github.io/json-ld-star/tests/",
+      "title": "Compaction",
+      "entries": [
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having no @id",
+          "assertions": [
+            {
+              "@id": "_:b534",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04",
+              "result": {
+                "@id": "_:b546",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st04-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st04-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b472",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st04-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having IRI @id",
+          "assertions": [
+            {
+              "@id": "_:b56",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05",
+              "result": {
+                "@id": "_:b380",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st05-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st05-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b57",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st05-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having BNode @id",
+          "assertions": [
+            {
+              "@id": "_:b47",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06",
+              "result": {
+                "@id": "_:b49",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st06-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st06-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b48",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st06-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having a type",
+          "assertions": [
+            {
+              "@id": "_:b436",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07",
+              "result": {
+                "@id": "_:b437",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st07-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st07-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b438",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st07-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having an IRI value",
+          "assertions": [
+            {
+              "@id": "_:b208",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08",
+              "result": {
+                "@id": "_:b209",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st08-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st08-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b51",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st08-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded subject having an BNode value",
+          "assertions": [
+            {
+              "@id": "_:b117",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09",
+              "result": {
+                "@id": "_:b541",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st09-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st09-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 6",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b118",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st09-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with recursive embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b419",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10",
+              "result": {
+                "@id": "_:b133",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st10-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st10-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 7",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b29",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st10-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded object",
+          "assertions": [
+            {
+              "@id": "_:b183",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15",
+              "result": {
+                "@id": "_:b185",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st15-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st15-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 8",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b184",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st15-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with embedded object having properties",
+          "assertions": [
+            {
+              "@id": "_:b8",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16",
+              "result": {
+                "@id": "_:b10",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st16-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st16-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 9",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b9",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st16-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with recursive embedded object",
+          "assertions": [
+            {
+              "@id": "_:b24",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17",
+              "result": {
+                "@id": "_:b217",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st17-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st17-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 10",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b25",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st17-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on value object",
+          "assertions": [
+            {
+              "@id": "_:b60",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18",
+              "result": {
+                "@id": "_:b62",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st18-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st18-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b61",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st18-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on node object",
+          "assertions": [
+            {
+              "@id": "_:b20",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19",
+              "result": {
+                "@id": "_:b179",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st19-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st19-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b21",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st19-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property multiple values",
+          "assertions": [
+            {
+              "@id": "_:b58",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20",
+              "result": {
+                "@id": "_:b449",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st20-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st20-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 3",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b59",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st20-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing multiple properties",
+          "assertions": [
+            {
+              "@id": "_:b22",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a",
+              "result": {
+                "@id": "_:b476",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st20a-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st20a-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 4",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b23",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st20a-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property containing an empty node object",
+          "assertions": [
+            {
+              "@id": "_:b11",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b",
+              "result": {
+                "@id": "_:b13",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st20b-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st20b-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Annotation node 5",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b12",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st20b-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded subject",
+          "assertions": [
+            {
+              "@id": "_:b43",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28",
+              "result": {
+                "@id": "_:b262",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st28-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st28-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b44",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st28-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Node with @annotation property on embedded object",
+          "assertions": [
+            {
+              "@id": "_:b45",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29",
+              "result": {
+                "@id": "_:b116",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st29-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st29-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Embedded annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b46",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st29-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node used as subject in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b542",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32",
+              "result": {
+                "@id": "_:b495",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st32-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st32-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 13",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b14",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st32-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "Embedded node used as object in reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b507",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33",
+              "result": {
+                "@id": "_:b431",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st33-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st33-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "embedded node 14",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b486",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st33-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "node with @annotation property on node object with reverse relationship",
+          "assertions": [
+            {
+              "@id": "_:b299",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34",
+              "result": {
+                "@id": "_:b396",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st34-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st34-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b103",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st34-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "reverse relationship inside annotation",
+          "assertions": [
+            {
+              "@id": "_:b425",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35",
+              "result": {
+                "@id": "_:b349",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st35-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st35-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Reverse annotation node 2",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b426",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st35-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "embedded node with an alias of `@id`",
+          "assertions": [
+            {
+              "@id": "_:b34",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36",
+              "result": {
+                "@id": "_:b36",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st36-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st36-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for embedded node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b35",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st36-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node with an alias of `@annotation`",
+          "assertions": [
+            {
+              "@id": "_:b88",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37",
+              "result": {
+                "@id": "_:b102",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st37-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st37-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "Alias for annotation node",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b89",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st37-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "embedded node with annotation on value object",
+          "assertions": [
+            {
+              "@id": "_:b40",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38",
+              "result": {
+                "@id": "_:b42",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st38-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st38-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation value 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b41",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st38-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an embedded node",
+          "assertions": [
+            {
+              "@id": "_:b3",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39",
+              "result": {
+                "@id": "_:b269",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st39-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st39-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with embedded node 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b4",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st39-out.jsonld"
+          }
+        },
+        {
+          "@id": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40",
+          "@type": [
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#CompactTest",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "rdfs:comment": "annotation node containing an annotation node",
+          "assertions": [
+            {
+              "@id": "_:b397",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/json-ld",
+              "assertedBy": "http://greggkellogg.net/foaf#me",
+              "test": "https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40",
+              "result": {
+                "@id": "_:b398",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "mode": "earl:automatic"
+            }
+          ],
+          "testAction": "https://json-ld.github.io/json-ld-star/tests/compact/st40-in.jsonld",
+          "testResult": "https://json-ld.github.io/json-ld-star/tests/compact/st40-out.jsonld",
+          "https://w3c.github.io/json-ld-api/tests/vocab#requires": "JSON-LD*",
+          "title": "annotation with annotation 1",
+          "https://w3c.github.io/json-ld-api/tests/vocab#option": {
+            "@id": "_:b55",
+            "https://w3c.github.io/json-ld-api/tests/vocab#rdfstar": {
+              "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+              "@value": "true"
+            },
+            "https://w3c.github.io/json-ld-api/tests/vocab#specVersion": "json-ld*"
+          },
+          "https://w3c.github.io/json-ld-api/tests/vocab#context": {
+            "@id": "https://json-ld.github.io/json-ld-star/tests/compact/st40-out.jsonld"
+          }
+        }
+      ]
+    }
+  ],
+  "bibRef": "[[json-ld-star]]"
 }

--- a/reports/index.html
+++ b/reports/index.html
@@ -6,7 +6,7 @@
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
 <link href='ruby-json-ld-earl.ttl' rel='related' />
 <title>
-JSON-LD* Processor Conformance
+JSON-LD-star Processor Conformance
 </title>
 <style type='text/css'>
   /*<![CDATA[*/
@@ -83,10 +83,10 @@ JSON-LD* Processor Conformance
 </a>
 </p>
 <h1 class='title p-name' id='title' property='dc:title'>
-JSON-LD* Processor Conformance
+JSON-LD-star Processor Conformance
 </h1>
 <h2 class='subtitle'>
-EARL results from the JSON-LD* Test Suite
+EARL results from the JSON-LD-star Test Suite
 </h2>
 <h2 id='w3c-document-28-october-2015'>
 <time class='dt-published' datetime='2021-02-12' property='dc:issued'>
@@ -123,7 +123,7 @@ rules apply.
 <h2>Abstract</h2>
 <p>
 This document report test subject conformance for and related specifications for
-<span property='doap:name'>JSON-LD* Test Suite</span>
+<span property='doap:name'>JSON-LD-star Test Suite</span>
 according to the requirements of the Evaluation and Report Language (EARL) 1.0 Schema
 [<a href='https://www.w3.org/TR/EARL10-Schema/'>EARL10-SCHEMA</a>].
 </p>
@@ -239,7 +239,7 @@ Report Generation Software
 <section id='introduction'>
 <h2>Introduction</h2>
 
-<p>This implementation report covers the implementations of the JSON-LD*
+<p>This implementation report covers the implementations of the JSON-LD-star
 specification which have submitted test results. It is intended to be
 maintained by the <a href="https://www.w3.org/community/json-ld/">JSON for Linking Data Community Group</a>.
 The implementation report serves two purposes:</p>
@@ -315,7 +315,6 @@ JSON::LD
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04'>Test tst04: embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -324,7 +323,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05'>Test tst05: embedded node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -333,7 +331,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06'>Test tst06: embedded node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -342,7 +339,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07'>Test tst07: embedded node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -351,7 +347,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08'>Test tst08: embedded node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -360,7 +355,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09'>Test tst09: embedded node 6</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -369,7 +363,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10'>Test tst10: embedded node 7</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -378,7 +371,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15'>Test tst15: embedded node 8</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -387,7 +379,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16'>Test tst16: embedded node 9</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -396,7 +387,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17'>Test tst17: embedded node 10</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -405,7 +395,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18'>Test tst18: Annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -414,7 +403,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19'>Test tst19: Annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -423,7 +411,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20'>Test tst20: Annotation node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -432,7 +419,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a'>Test tst20a: Annotation node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -441,7 +427,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b'>Test tst20b: Annotation node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -450,7 +435,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28'>Test tst28: Embedded annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -459,7 +443,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29'>Test tst29: Embedded annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -468,7 +451,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32'>Test tst32: embedded node 13</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -477,7 +459,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33'>Test tst33: embedded node 14</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -486,7 +467,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34'>Test tst34: Reverse annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -495,7 +475,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35'>Test tst35: Reverse annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -504,7 +483,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36'>Test tst36: Alias for embedded node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -513,7 +491,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37'>Test tst37: Alias for annotation node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -522,7 +499,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38'>Test tst38: annotation value 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -531,7 +507,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39'>Test tst39: annotation with embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -540,7 +515,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40'>Test tst40: annotation with annotation 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -579,7 +553,6 @@ JSON::LD
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01'>Test tst01: invalid embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -588,7 +561,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02'>Test tst02: ignored annotation 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -597,7 +569,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03'>Test tst03: ignored annotation 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -606,7 +577,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04'>Test tst04: embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -615,7 +585,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05'>Test tst05: embedded node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -624,7 +593,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06'>Test tst06: embedded node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -633,7 +601,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07'>Test tst07: embedded node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -642,7 +609,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08'>Test tst08: embedded node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -651,7 +617,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09'>Test tst09: embedded node 6</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -660,7 +625,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10'>Test tst10: embedded node 7</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -669,7 +633,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11'>Test tst11: invalid embedded node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -678,7 +641,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12'>Test tst12: invalid embedded node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -687,7 +649,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13'>Test tst13: invalid embedded node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -696,7 +657,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14'>Test tst14: invalid embedded node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -705,7 +665,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15'>Test tst15: embedded node 8</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -714,7 +673,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16'>Test tst16: embedded node 9</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -723,7 +681,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17'>Test tst17: embedded node 10</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -732,7 +689,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18'>Test tst18: Annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -741,7 +697,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19'>Test tst19: Annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -750,7 +705,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20'>Test tst20: Annotation node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -759,7 +713,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a'>Test tst20a: Annotation node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -768,7 +721,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b'>Test tst20b: Annotation node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -777,7 +729,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21'>Test tst21: Invalid annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -786,7 +737,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22'>Test tst22: Invalid annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -795,7 +745,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23'>Test tst23: Invalid annotation node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -804,7 +753,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24'>Test tst24: Invalid annotation node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -813,7 +761,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a'>Test tst24a: Invalid annotation node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -822,7 +769,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25'>Test tst25: Invalid annotation node 6</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -831,7 +777,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26'>Test tst26: Invalid annotation node 7</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -840,7 +785,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27'>Test tst27: Invalid annotation node 8</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -849,7 +793,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a'>Test tst27a: Invalid annotation node 9</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -858,7 +801,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28'>Test tst28: Embedded annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -867,7 +809,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29'>Test tst29: Embedded annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -876,7 +817,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30'>Test tst30: embedded node 11</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -885,7 +825,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31'>Test tst31: embedded node 12</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -894,7 +833,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32'>Test tst32: embedded node 13</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -903,7 +841,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33'>Test tst33: embedded node 14</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -912,7 +849,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34'>Test tst34: Reverse annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -921,7 +857,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35'>Test tst35: Reverse annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -930,7 +865,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36'>Test tst36: Alias for embedded node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -939,7 +873,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37'>Test tst37: Alias for annotation node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -948,7 +881,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38'>Test tst38: annotation value 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -957,7 +889,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39'>Test tst39: annotation with embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -966,7 +897,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40'>Test tst40: annotation with annotation 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1005,7 +935,6 @@ JSON::LD
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02'>Test tst02: ignored annotation 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1014,7 +943,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03'>Test tst03: ignored annotation 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1023,7 +951,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04'>Test tst04: embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1032,7 +959,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05'>Test tst05: embedded node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1041,7 +967,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06'>Test tst06: embedded node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1050,7 +975,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07'>Test tst07: embedded node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1059,7 +983,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08'>Test tst08: embedded node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1068,7 +991,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09'>Test tst09: embedded node 6</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1077,7 +999,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10'>Test tst10: embedded node 7</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1086,7 +1007,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15'>Test tst15: embedded node 8</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1095,7 +1015,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16'>Test tst16: embedded node 9</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1104,7 +1023,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17'>Test tst17: embedded node 10</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1113,7 +1031,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18'>Test tst18: Annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1122,7 +1039,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n'>Test tst18n: Annotation node 1 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1131,7 +1047,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19'>Test tst19: Annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1140,7 +1055,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n'>Test tst19n: Annotation node 2 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1149,7 +1063,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20'>Test tst20: Annotation node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1158,7 +1071,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n'>Test tst20n: Annotation node 3 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1167,7 +1079,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a'>Test tst20a: Annotation node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1176,7 +1087,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an'>Test tst20an: Annotation node 4 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1185,7 +1095,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b'>Test tst20b: Annotation node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1194,7 +1103,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn'>Test tst20bn: Annotation node 5 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1203,7 +1111,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28'>Test tst28: Embedded annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1212,7 +1119,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n'>Test tst28n: Embedded annotation node 1 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1221,7 +1127,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29'>Test tst29: Embedded annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1230,7 +1135,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n'>Test tst29n: Embedded annotation node 2 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1239,7 +1143,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32'>Test tst32: embedded node 13</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1248,7 +1151,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33'>Test tst33: embedded node 14</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1257,7 +1159,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34'>Test tst34: Reverse annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1266,7 +1167,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n'>Test tst34n: Reverse annotation node 1 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1275,7 +1175,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35'>Test tst35: Reverse annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1284,7 +1183,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n'>Test tst35n: Reverse annotation node 2 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1293,7 +1191,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36'>Test tst36: Alias for embedded node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1302,7 +1199,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37'>Test tst37: Alias for annotation node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1311,7 +1207,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38'>Test tst38: annotation value 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1320,7 +1215,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n'>Test tst38n: annotation value 1 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1329,7 +1223,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39'>Test tst39: annotation with embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1338,7 +1231,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n'>Test tst39n: annotation with embedded node 1 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1347,7 +1239,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40'>Test tst40: annotation with annotation 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1356,7 +1247,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n'>Test tst40n: annotation with annotation 1 (with @annotation)</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1395,7 +1285,6 @@ JSON::LD
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01'>Test tst01: invalid embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1404,7 +1293,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02'>Test tst02: ignored annotation 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1413,7 +1301,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03'>Test tst03: ignored annotation 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1422,7 +1309,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04'>Test tst04: embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1431,7 +1317,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05'>Test tst05: embedded node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1440,7 +1325,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06'>Test tst06: embedded node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1449,7 +1333,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07'>Test tst07: embedded node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1458,7 +1341,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08'>Test tst08: embedded node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1467,7 +1349,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09'>Test tst09: embedded node 6</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1476,7 +1357,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10'>Test tst10: embedded node 7</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1485,7 +1365,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11'>Test tst11: invalid embedded node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1494,7 +1373,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12'>Test tst12: invalid embedded node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1503,7 +1381,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13'>Test tst13: invalid embedded node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1512,7 +1389,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14'>Test tst14: invalid embedded node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1521,7 +1397,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15'>Test tst15: embedded node 8</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1530,7 +1405,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16'>Test tst16: embedded node 9</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1539,7 +1413,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17'>Test tst17: embedded node 10</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1548,7 +1421,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18'>Test tst18: Annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1557,7 +1429,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19'>Test tst19: Annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1566,7 +1437,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20'>Test tst20: Annotation node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1575,7 +1445,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a'>Test tst20a: Annotation node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1584,7 +1453,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b'>Test tst20b: Annotation node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1593,7 +1461,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21'>Test tst21: Invalid annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1602,7 +1469,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22'>Test tst22: Invalid annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1611,7 +1477,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23'>Test tst23: Invalid annotation node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1620,7 +1485,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24'>Test tst24: Invalid annotation node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1629,7 +1493,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a'>Test tst24a: Invalid annotation node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1638,7 +1501,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25'>Test tst25: Invalid annotation node 6</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1647,7 +1509,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26'>Test tst26: Invalid annotation node 7</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1656,7 +1517,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27'>Test tst27: Invalid annotation node 8</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1665,7 +1525,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a'>Test tst27a: Invalid annotation node 9</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1674,7 +1533,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28'>Test tst28: Embedded annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1683,7 +1541,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29'>Test tst29: Embedded annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1692,7 +1549,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30'>Test tst30: embedded node 11</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1701,7 +1557,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31'>Test tst31: embedded node 12</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1710,7 +1565,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32'>Test tst32: embedded node 13</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1719,7 +1573,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33'>Test tst33: embedded node 14</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1728,7 +1581,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34'>Test tst34: Reverse annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1737,7 +1589,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35'>Test tst35: Reverse annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1746,7 +1597,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36'>Test tst36: Alias for embedded node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1755,7 +1605,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37'>Test tst37: Alias for annotation node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1764,7 +1613,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38'>Test tst38: annotation value 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1773,7 +1621,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39'>Test tst39: annotation with embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1782,7 +1629,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40'>Test tst40: annotation with annotation 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1821,7 +1667,6 @@ JSON::LD
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02'>Test tst02: ignored annotation 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1830,7 +1675,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03'>Test tst03: ignored annotation 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1839,7 +1683,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04'>Test tst04: embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1848,7 +1691,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05'>Test tst05: embedded node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1857,7 +1699,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06'>Test tst06: embedded node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1866,7 +1707,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07'>Test tst07: embedded node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1875,7 +1715,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08'>Test tst08: embedded node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1884,7 +1723,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09'>Test tst09: embedded node 6</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1893,7 +1731,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10'>Test tst10: embedded node 7</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1902,7 +1739,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15'>Test tst15: embedded node 8</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1911,7 +1747,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16'>Test tst16: embedded node 9</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1920,7 +1755,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17'>Test tst17: embedded node 10</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1929,7 +1763,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18'>Test tst18: Annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1938,7 +1771,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19'>Test tst19: Annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1947,7 +1779,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20'>Test tst20: Annotation node 3</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1956,7 +1787,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a'>Test tst20a: Annotation node 4</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1965,7 +1795,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b'>Test tst20b: Annotation node 5</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1974,7 +1803,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28'>Test tst28: Embedded annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1983,7 +1811,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29'>Test tst29: Embedded annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -1992,7 +1819,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32'>Test tst32: embedded node 13</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -2001,7 +1827,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33'>Test tst33: embedded node 14</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -2010,7 +1835,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34'>Test tst34: Reverse annotation node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -2019,7 +1843,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35'>Test tst35: Reverse annotation node 2</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -2028,7 +1851,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36'>Test tst36: Alias for embedded node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -2037,7 +1859,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37'>Test tst37: Alias for annotation node</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -2046,7 +1867,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38'>Test tst38: annotation value 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -2055,7 +1875,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39'>Test tst39: annotation with embedded node 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -2064,7 +1883,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40'>Test tst40: annotation with annotation 1</a>
-(new in JSON-LD*)
 </td>
 <td class='PASS'>
 PASS
@@ -2185,7 +2003,7 @@ Individual test results used to construct this report are available here:
 </li>
 </ul>
 </section>
-<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='https://rubygems.org/gems/earl-report' typeof='Software doap:Project'>
+<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='https://rubygems.org/gems/earl-report' typeof='doap:Project Software'>
 <h2>
 <span class='secno'>C.</span>
 Report Generation Software

--- a/reports/manifests.nt
+++ b/reports/manifests.nt
@@ -1,2247 +1,2247 @@
-_:g16460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
 _:g16460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g16480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g16480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g16500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> .
-_:g16500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16520 .
-_:g16540 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g16540 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g16560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> .
-_:g16560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16580 .
-_:g16600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> .
-_:g16600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16620 .
-_:g16640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> .
-_:g16640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16660 .
-_:g16620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> .
-_:g16620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16680 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16540 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st06-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st06-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
+_:g16460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
 <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
 <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st06-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st06-out.jsonld> .
 <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st06-out.jsonld> .
-_:g16700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> .
-_:g16700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16720 .
-_:g16740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> .
-_:g16740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16760 .
-_:g16780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> .
-_:g16780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16800 .
-_:g16820 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g16820 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16840 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st09-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st09-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st09-out.jsonld> .
-_:g16860 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g16860 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16880 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st04-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st04-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st04-out.jsonld> .
-_:g16900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> .
-_:g16900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16920 .
-_:g16760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> .
-_:g16760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16940 .
-_:g16960 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g16960 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16480 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st05-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st05-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st05-out.jsonld> .
-_:g16980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> .
-_:g16980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16600 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16460 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st10-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st10-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st10-out.jsonld> .
-_:g17000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> .
-_:g17000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17020 .
-_:g17040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> .
-_:g17040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17060 .
-_:g16720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> .
-_:g16720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16500 .
-_:g17080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17100 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st16-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st16-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st16-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Compaction" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://json-ld.github.io/json-ld-star/tests/" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Compaction Algorithm](https://json-ld.github.io/json-ld-star#compaction-algorithm)." .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g16740 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17120 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st18-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st18-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st18-out.jsonld> .
-_:g17140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> .
-_:g17140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16780 .
-_:g16520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> .
-_:g16520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17140 .
-_:g17020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> .
-_:g17020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17160 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17180 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid @id value" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st01-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject without rdfstar option." .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 9" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17200 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st27a-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation that is an embedded node is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g17220 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17220 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 2" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17240 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st03-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st03-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/2000/01/rdf-schema#comment> "Value object with @annotation property is ignored without rdfstar option" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17260 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st39n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st39-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17280 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17280 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g16660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> .
-_:g16660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17300 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17320 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st22-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on a top-level graph node is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g17340 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17340 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17360 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17360 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16860 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st35-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st35-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st35-out.jsonld> .
-_:g17380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> .
-_:g17380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17400 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 12" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17420 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st31-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node with expanded reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g17440 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17440 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17440 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> .
-_:g17500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17520 .
-_:g17540 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17540 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> .
-_:g17560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17580 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 3" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17600 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st23-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property having @id is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g17620 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17620 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17660 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17660 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17680 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st02-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st02-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/2000/01/rdf-schema#comment> "Node object with @annotation property is ignored without rdfstar option." .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17700 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st28-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st28-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17720 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17720 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> .
-_:g17740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17760 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17780 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> .
-_:g17800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17820 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17840 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st09-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st09-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17860 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17860 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17880 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st17-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st17-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> .
-_:g17900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17920 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17940 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st18-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st18-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> .
-_:g17960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17980 .
-_:g18000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> .
-_:g18000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18020 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17080 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st29-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st29-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st29-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 2" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18040 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st03-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st03-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/2000/01/rdf-schema#comment> "Value object with @annotation property is ignored without rdfstar option" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18060 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st39-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st39-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> .
-_:g18080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18100 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18120 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st04-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st04-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18140 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st09-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st09-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> .
-_:g18160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18180 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18200 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st08-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st08-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18220 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st32-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st32-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18240 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st06-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st06-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g16680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> .
-_:g16680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17040 .
-_:g18260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> .
-_:g18260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18280 .
-_:g18300 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18300 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18300 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> .
-_:g18320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18340 .
-_:g18360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> .
-_:g18360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18380 .
-_:g18400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> .
-_:g18400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18420 .
-_:g18440 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18440 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> .
-_:g18480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18500 .
-_:g18520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> .
-_:g18520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18540 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18560 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20a-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20a-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> .
-_:g18580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18600 .
-_:g18620 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18620 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> .
-_:g18640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17380 .
-_:g18660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> .
-_:g18660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18680 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18700 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st15-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st15-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18720 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st29-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st29-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18560 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18560 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> .
-_:g18740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:g18760 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18760 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 1" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18780 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st02-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st02-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/2000/01/rdf-schema#comment> "Node object with @annotation property is ignored without rdfstar option." .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18800 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st34-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st34-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> .
-_:g18820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18840 .
-_:g18860 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18860 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18880 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st10-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st10-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18060 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18060 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18900 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st32-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st32-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18920 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18920 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18940 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st02-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st02-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/2000/01/rdf-schema#comment> "Node object with @annotation property is ignored without rdfstar option." .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17460 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st04-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st04-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18960 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid @id value" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st01-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject without rdfstar option." .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g18980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> .
-_:g18980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19000 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17440 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st38n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st38-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> .
-_:g18020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19020 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19040 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st35-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st35-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17480 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st19-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st19-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> .
-_:g19060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19080 .
-_:g19100 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19100 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17340 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st22-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on a top-level graph node is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g18340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> .
-_:g18340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19120 .
-_:g19140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> .
-_:g19140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19160 .
-_:g19180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> .
-_:g19180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19200 .
-_:g19220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> .
-_:g19220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18820 .
-_:g18420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> .
-_:g18420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19240 .
-_:g19260 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19260 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> .
-_:g19280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19300 .
-_:g19320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> .
-_:g19320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19340 .
-_:g19360 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19360 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> .
-_:g18280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19380 .
-_:g19400 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19400 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19420 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st32-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st32-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19440 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19440 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19460 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19480 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st15-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st15-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19500 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19500 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19520 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20an-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20a-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19540 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st40-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st40-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17840 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17840 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 6" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19560 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid set or list object" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st25-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/2000/01/rdf-schema#comment> "@annotation on a list" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g19580 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19580 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19600 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19600 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> .
-_:g17520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19620 .
-_:g19640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19640 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> .
-_:g19660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19680 .
-_:g19700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> .
-_:g19700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19720 .
-_:g19740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> .
-_:g19740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19760 .
-_:g19780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> .
-_:g19780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19800 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 2" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19820 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st03-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st03-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/2000/01/rdf-schema#comment> "Value object with @annotation property is ignored without rdfstar option" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19840 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st19-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st19-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st19-out.jsonld> .
-_:g19560 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19560 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19860 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19860 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> .
-_:g19200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19880 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16960 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st08-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st08-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st08-out.jsonld> .
-_:g19900 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19900 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> .
-_:g19920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19700 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19440 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st18-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st18-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> .
-_:g19940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19960 .
-_:g17320 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17320 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17220 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st35-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st35-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> .
-_:g19980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18740 .
-_:g19000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> .
-_:g19000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19920 .
-_:g20000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> .
-_:g20000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20020 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20040 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st32-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st32-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st32-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20060 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st05-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st05-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19540 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19540 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20080 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st07-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st07-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20100 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20100 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20120 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20120 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19260 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st36-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st36-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st36-out.jsonld> .
-_:g18600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> .
-_:g18600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20140 .
-_:g20160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> .
-_:g20160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20180 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st36-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st36-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19100 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20a-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20a-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19400 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st36-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st36-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20200 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st40-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st40-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> .
-_:g20220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20240 .
-_:g19380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> .
-_:g19380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20260 .
-_:g20280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> .
-_:g20280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20300 .
-_:g20320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> .
-_:g20320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20340 .
-_:g20360 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20360 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17620 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st37-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st37-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20380 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st29-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st29-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20400 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20400 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20420 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20420 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20420 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20440 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20440 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17880 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17880 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20480 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st39-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st39-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st39-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 8" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20500 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st27-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/2000/01/rdf-schema#comment> "@annotation property on a top-level @included node is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g20500 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20500 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20520 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20520 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 6" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18920 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid set or list object" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st25-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/2000/01/rdf-schema#comment> "@annotation on a list" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g20540 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20540 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 8" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20560 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st27-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/2000/01/rdf-schema#comment> "@annotation property on a top-level @included node is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20580 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st07-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st07-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st07-out.jsonld> .
-_:g20600 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20600 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20620 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20620 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16820 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st20-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st20-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st20-out.jsonld> .
-_:g20640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> .
-_:g19240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20660 .
-_:g17160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> .
-_:g17160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16900 .
-_:g20680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> .
-_:g20680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20700 .
-_:g20720 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20720 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20740 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20740 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> .
-_:g20760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20780 .
-_:g20800 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20800 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17680 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17680 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20820 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20820 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20820 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 2 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20820 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st29n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st29-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19900 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st38-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st38-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 9" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20840 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st27a-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation that is an embedded node is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g16800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> .
-_:g16800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20860 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19500 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st17-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st17-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> .
-_:g19160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20880 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20400 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st33-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st33-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20900 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st04-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st04-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20920 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20920 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20940 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20940 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19820 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19820 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20960 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20960 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> .
-_:g20340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19740 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Expansion" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://w3c.github.io/json-ld-api/tests/" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Expansion Algorithm](https://json-ld.github.io/json-ld-star#expansion-algorithm)." .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g20320 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20980 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st16-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st16-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20040 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20040 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21000 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21000 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21020 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21020 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20720 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st10-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st10-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21040 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st28-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st28-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21060 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st05-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st05-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g21080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21100 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st37-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st37-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 12" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21120 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st31-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node with expanded reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g21140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> .
-_:g21140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21160 .
-_:g21180 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21180 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21200 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st28-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st28-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> .
-_:g19720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21220 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 4" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19580 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st13-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having multiple types" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g21240 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21240 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 5" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21260 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st24a-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property with value object value is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17640 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st37-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st37-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st37-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 3" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17360 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st23-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property having @id is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21280 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st36-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st36-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> .
-_:g18500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20160 .
-_:g21300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> .
-_:g21300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21320 .
-_:g21340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> .
-_:g21340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19140 .
-_:g21360 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21360 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21380 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st19-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st19-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18760 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st40-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st40-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g21400 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21400 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> .
-_:g21420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21440 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Transform RDF to JSON-LD" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://w3c.github.io/json-ld-api/tests/" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Serialize RDF as JSON-LD Algorithm](https://json-ld.github.io/json-ld-star#serialize-rdf-as-json-ld-algorithm)." .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g19940 .
-_:g21460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> .
-_:g21220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21480 .
-_:g21500 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21500 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> .
-_:g20780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18400 .
-_:g21520 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21520 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21520 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21540 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21540 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> .
-_:g21440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21560 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 3" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21580 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st12-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having multiple properties" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g18780 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18780 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18300 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st35n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st35-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18700 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18700 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21600 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21600 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> .
-_:g21620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18480 .
-_:g21640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21080 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st10-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st10-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g16840 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g16840 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> .
-_:g19880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21660 .
-_:g21680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> .
-_:g21680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21700 .
-_:g21720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> .
-_:g21720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20280 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 4" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20640 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st24-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property with simple value is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21740 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21540 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20b-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20b-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21760 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st36-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st36-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Flattening" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://w3c.github.io/json-ld-api/tests/" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Flattening Algorithm](https://json-ld.github.io/json-ld-star#flattening-algorithm)." .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g20760 .
-_:g21780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> .
-_:g21780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18640 .
-_:g21800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> .
-_:g21800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20000 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 3" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21640 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st12-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having multiple properties" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20420 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20b-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20b-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20180 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20180 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> .
-_:g21820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21840 .
-_:g18380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> .
-_:g18380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21860 .
-_:g21860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> .
-_:g21860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19320 .
-_:g20060 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20060 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20840 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20840 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> .
-_:g21880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21900 .
-_:g21920 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21920 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> .
-_:g18100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18980 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21940 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st08-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st08-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g21380 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21380 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21100 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21100 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21960 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st04-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st04-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g21980 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21980 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18720 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18720 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 7" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17860 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st26-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation on a list value" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g21040 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21040 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22000 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22000 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20560 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20560 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17700 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17700 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21120 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21120 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> .
-_:g19800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19660 .
-_:g16940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> .
-_:g16940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16700 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20920 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st20b-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st20b-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22020 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st38-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st38-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st38-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22040 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st06-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st06-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17660 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st34-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st34-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22060 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st28-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st28-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> .
-_:g22100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22120 .
-_:g17920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> .
-_:g17920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21680 .
-_:g18540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> .
-_:g18540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22140 .
-_:g22160 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22160 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22180 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st16-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st16-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 7" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17540 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st26-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation on a list value" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g21580 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21580 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> .
-_:g22220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21620 .
-_:g19840 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19840 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> .
-_:g22240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18260 .
-_:g17100 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17100 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> .
-_:g22260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:g22280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> .
-_:g22280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16560 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22160 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st20-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st20-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22300 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17600 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17600 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18040 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18040 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22320 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st19-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st19-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21460 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st32-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st32-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22060 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22060 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19040 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19040 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22340 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20a-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20a-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22020 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22020 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 2" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20100 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st11-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having no property" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g22360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> .
-_:g22360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16640 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21600 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st19-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st19-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> .
-_:g22380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 5" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22400 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st14-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having type and property" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 5" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22420 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st24a-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property with value object value is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g20020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> .
-_:g20020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22440 .
-_:g19680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> .
-_:g19680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18320 .
-_:g22460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18940 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18940 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19600 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st34-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st34-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> .
-_:g22480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21880 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22500 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st17-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st17-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st17-out.jsonld> .
-_:g17240 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17240 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> .
-_:g19960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22520 .
-_:g22540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> .
-_:g22540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22220 .
-_:g22560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> .
-_:g22560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22580 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22600 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st40-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st40-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st40-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 2" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20120 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st11-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having no property" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g17060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> .
-_:g17060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:g17120 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17120 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> .
-_:g18680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21820 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22620 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st39-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st39-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g21320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> .
-_:g21320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22640 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22660 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20b-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20b-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17260 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17260 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17260 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20800 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st40-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st40-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> .
-_:g22680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22700 .
-_:g22720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> .
-_:g22720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17500 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19860 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st20a-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st20a-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22740 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22740 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> .
-_:g22760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19980 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19360 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st35-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st35-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20360 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st29-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st29-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18440 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st37-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st37-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21000 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st34-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st34-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> .
-_:g19300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22780 .
-_:g22780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> .
-_:g22780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19780 .
-_:g22800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> .
-_:g22800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22820 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22840 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st15-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st15-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22860 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20b-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20b-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22880 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22880 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22900 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st33-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st33-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20940 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st33-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st33-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19520 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19520 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19520 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22920 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22920 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> .
-_:g22940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20220 .
-_:g22900 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22900 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22840 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22840 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22960 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st28-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st28-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st28-out.jsonld> .
-_:g20700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> .
-_:g20700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16980 .
-_:g18840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> .
-_:g18840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18520 .
-_:g22980 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22980 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> .
-_:g17820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23000 .
-_:g23020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> .
-_:g23020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17960 .
-_:g23040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> .
-_:g23040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23020 .
-_:g22500 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22500 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21960 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21960 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23060 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st19n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st19-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g23080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> .
-_:g23080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19280 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 5" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23100 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st14-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having type and property" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g23120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> .
-_:g23120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23140 .
-_:g23160 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23160 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23180 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st09-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st09-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22300 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22300 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> .
-_:g23200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23220 .
-_:g23240 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23240 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> .
-_:g23220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18360 .
-_:g23260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> .
-_:g23260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23280 .
-_:g23300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> .
-_:g23300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22260 .
-_:g23320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> .
-_:g23320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22800 .
-_:g23340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> .
-_:g23340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22560 .
-_:g22140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> .
-_:g22140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23340 .
-_:g21660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> .
-_:g21660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23300 .
-_:g22400 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22400 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18900 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18900 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> .
-_:g23360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21720 .
-_:g21260 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21260 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23380 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23380 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> .
-_:g20260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22940 .
-_:g21760 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21760 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23380 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st39-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st39-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19420 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g19420 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> .
-_:g23280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23400 .
-_:g23420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> .
-_:g23420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23260 .
-_:g22120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> .
-_:g22120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20680 .
-_:g22440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> .
-_:g22440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22380 .
-_:g20480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> .
-_:g20660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22720 .
-_:g16580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> .
-_:g16580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22680 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20960 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st17-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st17-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21980 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st05-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st05-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g23440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> .
-_:g23440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23460 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23480 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st08-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st08-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> .
-_:g19340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23360 .
-_:g19020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> .
-_:g19020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18160 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 4" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20740 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st13-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having multiple types" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g22960 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22960 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20620 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st07-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st07-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20580 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20580 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> .
-_:g17300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18580 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23500 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st37-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st37-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18620 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st38-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st38-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22600 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22600 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18220 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18220 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22420 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22420 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23520 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23520 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> .
-_:g17980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22360 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17280 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st39-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st39-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22980 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st06-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st06-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> .
-_:g20880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23540 .
-_:g21060 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21060 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23100 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23100 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22180 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22180 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g19120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> .
-_:g19120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21800 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23560 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st20b-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st20b-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16480 .
 <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
 <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st20b-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st20b-out.jsonld> .
 <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st20b-out.jsonld> .
-_:g23580 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23580 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18120 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18120 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 2" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21920 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st03-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st03-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/2000/01/rdf-schema#comment> "Value object with @annotation property is ignored without rdfstar option" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g23400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> .
-_:g23400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21780 .
-_:g23560 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23560 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23520 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st05-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st05-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22920 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st16-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st16-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19640 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st28n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st28-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g19760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> .
-_:g19760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23040 .
-_:g18960 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18960 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23600 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23600 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22620 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22620 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18880 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18880 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> .
-_:g22640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17900 .
-_:g19620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> .
-_:g19620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17560 .
-_:g21480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> .
-_:g21480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21420 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21400 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g23620 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23620 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> .
-_:g21560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23320 .
-_:g20240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> .
-_:g20240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19220 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18860 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st16-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st16-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16500 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://json-ld.github.io/json-ld-star/tests/" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g16520 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Compaction" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Compaction Algorithm](https://json-ld.github.io/json-ld-star#compaction-algorithm)." .
+_:g16540 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g16540 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g16560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> .
+_:g16560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16580 .
+_:g16600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> .
+_:g16600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16620 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st18-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st18-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st18-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16640 .
+_:g16660 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g16660 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g16680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> .
+_:g16680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16600 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st08-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st08-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st08-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16700 .
+_:g16720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> .
+_:g16720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16740 .
+_:g16760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> .
+_:g16760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16780 .
+_:g16800 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g16800 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g16820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> .
+_:g16820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16840 .
+_:g16860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> .
+_:g16860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16880 .
+_:g16900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> .
+_:g16900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16760 .
+_:g16920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> .
+_:g16920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16560 .
+_:g16940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> .
+_:g16940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16960 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st16-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st16-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st16-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16980 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st32-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st32-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st32-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16540 .
+_:g16700 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g16700 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st17-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st17-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st17-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17000 .
+_:g16620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> .
+_:g16620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17020 .
+_:g16840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> .
+_:g16840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17040 .
+_:g16580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> .
+_:g16580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17060 .
+_:g17080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> .
+_:g17080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17100 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st38-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st38-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st38-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16660 .
+_:g17120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> .
+_:g17120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17140 .
+_:g16520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> .
+_:g16520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16860 .
+_:g17160 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17160 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> .
+_:g17060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17080 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st09-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st09-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17180 .
+_:g17200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17220 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17220 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17240 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17240 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17260 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17260 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> .
+_:g17280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17300 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st20-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st20-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17320 .
+_:g17340 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17340 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> .
+_:g17360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17380 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st40-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st40-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17400 .
+_:g17420 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17420 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
 <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
 <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21520 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st40n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st40-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g16920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> .
-_:g16920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22100 .
-_:g17420 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17420 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22320 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22320 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g20860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> .
-_:g20860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17000 .
-_:g21900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> .
-_:g21900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23640 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22740 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st18-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st18-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> .
-_:g17580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23200 .
-_:g17400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> .
-_:g17400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23440 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21180 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st38-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st38-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st16-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st16-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17440 .
+_:g17460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17500 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17500 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17500 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17520 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st05-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st05-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17540 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st28-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st28-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17560 .
+_:g17580 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17580 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st26-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 7" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation on a list value" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17600 .
+_:g17620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> .
+_:g17620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17640 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st29-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st29-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st29-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17660 .
+_:g17680 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17680 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st28-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st28-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17700 .
+_:g17720 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17720 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> .
+_:g17740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17760 .
+_:g17780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> .
+_:g17780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17800 .
+_:g17820 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17820 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17820 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
 <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
 <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22040 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22040 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23580 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st21-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property that is on the top-level is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g21160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> .
-_:g21160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21300 .
-_:g23000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> .
-_:g23000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18000 .
-_:g22340 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22340 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23660 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st18n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st18-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> .
-_:g22580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18660 .
-_:g21200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 11" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23620 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st30-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node with reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22200 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st06-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st06-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> .
-_:g20140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23420 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23240 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st10-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st10-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st38-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st38-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17840 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st13-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 4" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having multiple types" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17860 .
+_:g17880 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17880 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st39-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st39-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st39-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17900 .
+_:g17920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> .
+_:g17920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17940 .
+_:g17960 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17960 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17980 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17980 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> .
+_:g18000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18020 .
+_:g18040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> .
+_:g18040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18060 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st02-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st02-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <http://www.w3.org/2000/01/rdf-schema#comment> "Node object with @annotation property is ignored without rdfstar option." .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18080 .
+_:g18100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> .
+_:g18100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17280 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st36-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st36-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st36-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18120 .
+_:g18140 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18140 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> .
+_:g18160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18180 .
+_:g18200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st40-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st40-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18220 .
+_:g18240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> .
+_:g18240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17740 .
+_:g18260 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18260 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18260 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st27-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 8" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <http://www.w3.org/2000/01/rdf-schema#comment> "@annotation property on a top-level @included node is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18280 .
+_:g18300 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18300 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27> .
+_:g18320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18340 .
+_:g18360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> .
+_:g18360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18380 .
+_:g16780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst32> .
+_:g16780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16940 .
+_:g18400 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18400 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st23-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 3" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property having @id is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17460 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st29-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st29-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18420 .
+_:g18440 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18440 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> .
+_:g17300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18460 .
+_:g18480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> .
+_:g18480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18500 .
+_:g18520 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18520 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18540 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st40-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st40-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st40-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16460 .
+_:g18560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> .
+_:g18560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18580 .
+_:g18020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> .
+_:g18020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18600 .
+_:g18620 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18620 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18660 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18660 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18680 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18680 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18700 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18700 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18700 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18720 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18720 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst28> .
+_:g18180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18740 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st05-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st05-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18680 .
+_:g18760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> .
+_:g18760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18780 .
+_:g18800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> .
+_:g18800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17620 .
+_:g18820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> .
+_:g18820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18840 .
 <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
 <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20900 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20900 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> .
-_:g21840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18080 .
-_:g20980 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20980 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> .
-_:g21700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19180 .
-_:g22660 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22660 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Transform JSON-LD to RDF" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://w3c.github.io/json-ld-api/tests/" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Deserialize JSON-LD to RDF Algorithm](https://json-ld.github.io/json-ld-star#deserialize-json-ld-to-rdf-algorithm)." .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g22240 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23680 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st20a-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st20a-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st20a-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21020 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st35-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st35-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g18240 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18240 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g21940 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21940 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17780 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17780 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g17780 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23600 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st15-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st15-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g21740 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21740 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21240 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st33-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st33-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st33-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22880 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st29-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st29-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20540 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st38-out.nq> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st38-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20600 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st15-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st15-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st15-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23700 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st33-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st33-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g17940 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17940 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g16880 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g16880 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23160 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st07-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st07-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> .
-_:g22520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23120 .
-_:g22860 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g22860 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23680 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23680 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17720 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st18-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st18-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g22700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> .
-_:g22700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22760 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 11" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18460 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st30-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node with reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g17760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> .
-_:g17760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22540 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20520 .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st07-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st07-in.nq> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g23540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> .
-_:g23540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19060 .
-_:g23500 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23500 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> .
-_:g23640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21340 .
-_:g20300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> .
-_:g20300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23720 .
-_:g18800 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18800 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18140 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18140 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> .
-_:g23460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22480 .
-_:g21280 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g21280 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23060 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23060 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23060 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> .
-_:g18180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21140 .
-_:g19080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> .
-_:g19080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22280 .
-_:g20380 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20380 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g18200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g18200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20440 .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st09-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st09-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
-<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g20200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g20200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 4" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22000 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st24-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property with simple value is invalid" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
-_:g23140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> .
-_:g23140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17800 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 1" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20460 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st02-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st02-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/2000/01/rdf-schema#comment> "Node object with @annotation property is ignored without rdfstar option." .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g23180 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23180 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g22820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> .
-_:g22820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17740 .
-_:g17180 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g17180 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21360 .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st34-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st34-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
-<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st34-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22460 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st17-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st17-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st10-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st10-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18860 .
+_:g18880 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18880 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18900 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18900 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g16740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst18> .
+_:g16740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16680 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st15-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st15-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18920 .
+_:g18940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> .
+_:g18940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18960 .
+_:g18980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20> .
+_:g18980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19000 .
+_:g19020 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19020 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19040 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19040 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19060 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19060 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17000 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17000 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17560 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17560 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> .
+_:g18780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19100 .
+_:g17940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> .
+_:g17940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19120 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st39-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st39-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19140 .
+_:g19160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> .
+_:g19160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19180 .
+_:g19200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> .
+_:g19220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19240 .
+_:g19260 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19260 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st08-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st08-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19280 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st06-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st06-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19300 .
+_:g19320 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19320 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19340 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19340 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19280 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19280 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> .
+_:g19360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19380 .
+_:g18340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> .
+_:g18340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19400 .
+_:g19420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> .
+_:g19420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17780 .
+_:g17400 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17400 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st40-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st40-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19440 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st34-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st34-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19460 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st01-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid @id value" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject without rdfstar option." .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19480 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st31-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 12" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node with expanded reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19500 .
+_:g19520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> .
+_:g19520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19540 .
 <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
 <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g23660 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23660 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23660 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:g23700 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
-_:g23700 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21500 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st08-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st08-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-_:g23720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> .
-_:g23720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23080 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1 (with @annotation)" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19460 .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st34n-out.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st34-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
-<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 1" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22080 .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st21-in.jsonld> .
-<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property that is on the top-level is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st17-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st17-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19040 .
+_:g19560 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19560 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st40-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st40-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19580 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st10-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st10-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19600 .
+_:g19620 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19620 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19620 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st30-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 11" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node with reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19640 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st37-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st37-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st37-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18400 .
+_:g19660 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19660 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19680 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19680 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st16-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st16-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19700 .
+_:g19720 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19720 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st08-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st08-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19740 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st02-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st02-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <http://www.w3.org/2000/01/rdf-schema#comment> "Node object with @annotation property is ignored without rdfstar option." .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19760 .
+_:g19780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> .
+_:g19780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19800 .
+_:g19820 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19820 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> .
+_:g18060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18000 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st36-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st36-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19840 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st10-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st10-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18620 .
+_:g19860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> .
+_:g19860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19880 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st03-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st03-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 2" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <http://www.w3.org/2000/01/rdf-schema#comment> "Value object with @annotation property is ignored without rdfstar option" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18660 .
+_:g19900 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19900 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st19-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st19-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19920 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20b-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20b-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19940 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st09-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st09-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19960 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st22-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on a top-level graph node is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19980 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st34-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st34-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st34-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20000 .
+_:g20020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> .
+_:g20020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20040 .
+_:g20060 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20060 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17520 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17520 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17520 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st18-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st18-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20080 .
+_:g19400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst28> .
+_:g19400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20100 .
+_:g20120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> .
+_:g20120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19860 .
+_:g20140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> .
+_:g20140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20160 .
+_:g20180 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20180 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> .
+_:g20200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20220 .
+_:g20240 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20240 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st29-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st29-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20260 .
+_:g20280 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20280 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st14-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 5" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having type and property" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17720 .
+_:g17800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> .
+_:g17800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18980 .
+_:g20300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> .
+_:g20300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20320 .
+_:g20340 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20340 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st32-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st32-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20360 .
+_:g20380 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20380 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst08> .
+_:g20400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20420 .
+_:g17840 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17840 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20360 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20360 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://w3c.github.io/json-ld-api/tests/" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g20440 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Expansion" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Expansion Algorithm](https://json-ld.github.io/json-ld-star#expansion-algorithm)." .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st33-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st33-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17480 .
+_:g20460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> .
+_:g20460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20480 .
+_:g20500 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20500 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st32-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st32-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17260 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st30-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 11" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node with reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20060 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st13-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 4" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having multiple types" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20520 .
+_:g17600 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17600 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20540 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20540 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19580 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19580 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st10-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st10-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st10-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g16800 .
+_:g20560 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20560 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20580 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20580 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st20-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st20-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st20-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20540 .
+_:g20600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> .
+_:g20600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20620 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st24a-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 5" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property with value object value is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20640 .
+_:g20660 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20660 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> .
+_:g20680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18820 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st34-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st34-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20700 .
+_:g20720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst15> .
+_:g20720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20740 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st32-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st32-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20760 .
+_:g20780 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20780 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st03-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st03-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 2" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <http://www.w3.org/2000/01/rdf-schema#comment> "Value object with @annotation property is ignored without rdfstar option" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20800 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st24a-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 5" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property with value object value is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20820 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st24-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 4" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property with simple value is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20840 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20b-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20b-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19820 .
+_:g20860 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20860 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> .
+_:g20880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20900 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st07-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st07-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20920 .
+_:g18080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20940 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20940 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> .
+_:g20960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20880 .
 <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
 <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st21-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property that is on the top-level is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20980 .
+_:g21000 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21000 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21020 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21020 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21040 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21040 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st28-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st28-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21060 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st18-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st18-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21080 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st16-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st16-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21100 .
+_:g21120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> .
+_:g21120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18160 .
+_:g21140 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21140 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19600 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19600 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st15-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st15-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st15-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21160 .
+_:g21180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> .
+_:g21180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21200 .
+_:g20760 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20760 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> .
+_:g21220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21240 .
+_:g21160 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21160 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st04-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st04-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st04-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17160 .
+_:g21260 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21260 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> .
+_:g18740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21280 .
+_:g21300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40> .
+_:g21300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21320 .
+_:g18460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> .
+_:g18460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21340 .
+_:g18500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst40> .
+_:g18500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st06-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st06-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19320 .
+_:g21360 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21360 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17860 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17860 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> .
+_:g19180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21380 .
+_:g20700 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20700 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> .
+_:g21400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21420 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st07-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st07-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21440 .
+_:g21460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g16880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst06> .
+_:g16880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16920 .
+_:g21480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst06> .
+_:g21480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21500 .
+_:g21520 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21520 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19700 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19700 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst02> .
+_:g21540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21560 .
+_:g21580 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21580 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st03-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st03-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 2" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <http://www.w3.org/2000/01/rdf-schema#comment> "Value object with @annotation property is ignored without rdfstar option" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21600 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st33-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st33-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19720 .
+_:g16960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst34> .
+_:g16960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21620 .
+_:g21640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17700 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17700 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st27-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 8" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <http://www.w3.org/2000/01/rdf-schema#comment> "@annotation property on a top-level @included node is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18520 .
+_:g21660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst03> .
+_:g21660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21680 .
+_:g21700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> .
+_:g21700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21720 .
+_:g21740 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21740 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst26> .
+_:g21760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21780 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://w3c.github.io/json-ld-api/tests/" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g21800 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Flattening" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Flattening Algorithm](https://json-ld.github.io/json-ld-star#flattening-algorithm)." .
+_:g21820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst30> .
+_:g21820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21840 .
+_:g21860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> .
+_:g21860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20720 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st31-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 12" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node with expanded reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst31> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17200 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st32-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st32-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 13" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as subject in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18300 .
+_:g21880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst30> .
+_:g21880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18940 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st09-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st09-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21900 .
+_:g18600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18> .
+_:g18600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21920 .
+_:g20260 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20260 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> .
+_:g21940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21960 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st15-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st15-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21980 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st17-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st17-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22000 .
+_:g21720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34> .
+_:g21720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22020 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st19-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st19-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st19-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21260 .
+_:g22040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> .
+_:g22040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22060 .
+_:g18540 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18540 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst08> .
+_:g22100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22120 .
+_:g20620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst19> .
+_:g20620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22140 .
+_:g19960 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19960 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22160 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22160 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22160 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st37-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st37-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17240 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st39-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st39-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22180 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st04-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st04-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22200 .
+_:g19140 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19140 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22220 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22220 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22220 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18420 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18420 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st07-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st07-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18140 .
+_:g21800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> .
+_:g21800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21660 .
+_:g20160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst40> .
+_:g20160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:g21200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> .
+_:g21200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18480 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st38-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st38-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20240 .
+_:g22240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> .
+_:g22240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22260 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st38-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st38-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20780 .
+_:g21100 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21100 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st34-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st34n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17820 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st05-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st05-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22280 .
+_:g17380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> .
+_:g17380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22300 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st04-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st04-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22320 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st12-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 3" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having multiple properties" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22340 .
+_:g19540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst02> .
+_:g19540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20020 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st36-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st36-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17880 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st36-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st36-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22360 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st07-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st07-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21020 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st08-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st08-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22380 .
+_:g22400 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22400 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22420 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22420 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst07> .
+_:g21500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22100 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st09-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st09-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st09-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19340 .
+_:g22440 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22440 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20b-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20b-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21520 .
+_:g20900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst36> .
+_:g20900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21180 .
+_:g17040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst40> .
+_:g17040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:g18920 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18920 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20a-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20a-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17220 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st17-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st17-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20560 .
+_:g22460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st20a-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st20a-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22080 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st20a-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st20a-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st20a-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22440 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st14-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 5" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having type and property" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst14> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22480 .
+_:g22500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst32> .
+_:g22500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21700 .
+_:g18580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> .
+_:g18580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21300 .
+_:g22520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst14> .
+_:g22520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18100 .
+_:g22540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> .
+_:g22540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22240 .
+_:g21060 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21060 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22560 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22560 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st17-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st17-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 10" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21460 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st28-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st28n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17500 .
+_:g22580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> .
+_:g22580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18360 .
+_:g22600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst22> .
+_:g22600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17360 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st19-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st19-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19020 .
+_:g22620 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22620 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22620 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st16-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st16-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 9" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object having properties" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18440 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st10-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st10-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 7" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with recursive embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst10> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20660 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st06-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st06-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19660 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st01-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid @id value" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject without rdfstar option." .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst01> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22640 .
+_:g22660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst17> .
+_:g22660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20600 .
+_:g22360 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22360 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19940 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19940 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst29> .
+_:g20100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21880 .
+_:g22680 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22680 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22180 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22180 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst36> .
+_:g19100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22700 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st12-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 3" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having multiple properties" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17420 .
+_:g21980 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21980 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst05> .
+_:g21380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21480 .
+_:g21280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst32> .
+_:g21280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19220 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st18-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st18-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22720 .
+_:g22740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst13> .
+_:g22740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21860 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st18-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st18n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22760 .
+_:g21340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> .
+_:g21340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22780 .
+_:g22060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst12> .
+_:g22060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22800 .
+_:g18280 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18280 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://w3c.github.io/json-ld-api/tests/" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g19520 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Transform JSON-LD to RDF" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Deserialize JSON-LD to RDF Algorithm](https://json-ld.github.io/json-ld-star#deserialize-json-ld-to-rdf-algorithm)." .
+_:g20920 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20920 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g16500 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g16500 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19840 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19840 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22000 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22000 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst01> .
+_:g20440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21540 .
+_:g17900 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17900 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19760 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19760 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st34-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st34-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22820 .
+_:g22140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> .
+_:g22140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21120 .
+_:g21240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20n> .
+_:g21240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22580 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://w3c.github.io/json-ld-api/tests/" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g22840 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Transform RDF to JSON-LD" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "These tests implement the requirements for the JSON-LD* [Serialize RDF as JSON-LD Algorithm](https://json-ld.github.io/json-ld-star#serialize-rdf-as-json-ld-algorithm)." .
+_:g17760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> .
+_:g17760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22860 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st33-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st33-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st33-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19080 .
+_:g22880 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22880 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> .
+_:g22700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22900 .
+_:g22920 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22920 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22920 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st39-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st39n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22160 .
+_:g17660 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17660 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20b> .
+_:g22940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22960 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st23-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 3" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property having @id is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst23> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18640 .
+_:g20640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18120 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18120 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st15-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st15-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22980 .
+_:g20840 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20840 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20> .
+_:g22780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17120 .
+_:g20080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> .
+_:g23000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20960 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20a-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20a-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21580 .
+_:g23020 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23020 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> .
+_:g22260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21820 .
+_:g21420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29> .
+_:g21420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23040 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st38-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st38n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18700 .
+_:g22480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst31> .
+_:g21840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23060 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20a-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st20a-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19200 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st19-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st19-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21140 .
+_:g20980 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20980 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20800 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20800 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st19-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st19n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23080 .
+_:g23100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst28> .
+_:g23100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21400 .
+_:g22120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst09> .
+_:g22120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23120 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st39-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st39-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19060 .
+_:g18840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst12> .
+_:g18840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22740 .
+_:g23140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst10> .
+_:g23140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22040 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st02-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st02-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 1" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <http://www.w3.org/2000/01/rdf-schema#comment> "Node object with @annotation property is ignored without rdfstar option." .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22420 .
+_:g23160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst37> .
+_:g23160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16820 .
+_:g16980 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g16980 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st33-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st33-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21360 .
+_:g21560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst03> .
+_:g21560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18240 .
+_:g23180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst09> .
+_:g23180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20680 .
+_:g23060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst32> .
+_:g23060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23000 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st35-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st35n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22620 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st29-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st29-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23200 .
+_:g22320 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22320 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23220 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23220 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> .
+_:g20320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20120 .
+_:g17180 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17180 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst08> .
+_:g19120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23180 .
+_:g17640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst07> .
+_:g17640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19360 .
+_:g17320 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17320 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st07-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st07-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st07-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 4" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having a type" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst07> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23220 .
+_:g17140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> .
+_:g17140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23240 .
+_:g19880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst40> .
+_:g19880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:g23260 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23260 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st26-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 7" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation on a list value" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18880 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st19-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st19-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on node object" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst19> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17580 .
+_:g18380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20b> .
+_:g18380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23280 .
+_:g18960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst32> .
+_:g18960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23300 .
+_:g23040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> .
+_:g23040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22500 .
+_:g18860 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18860 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst07> .
+_:g22860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20400 .
+_:g21900 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21900 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st29-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st29n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 2 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst29n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22920 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st33-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st33-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 14" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <http://www.w3.org/2000/01/rdf-schema#comment> "Embedded node used as object in reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst33> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20340 .
+_:g22200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst05> .
+_:g23320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g17920 .
+_:g23340 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23340 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st06-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st06-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 3" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having BNode @id" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst06> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23360 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st25-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid set or list object" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 6" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <http://www.w3.org/2000/01/rdf-schema#comment> "@annotation on a list" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst25> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20280 .
+_:g21920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst18n> .
+_:g21920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21940 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st09-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st09-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 6" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an BNode value" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20500 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st20-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17340 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st20b-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st20b-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst20b> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23380 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st35-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st35-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21000 .
+_:g22280 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22280 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19460 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19460 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst36> .
+_:g23400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23160 .
+_:g22720 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22720 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst37> .
+_:g23420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23440 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st37-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st37-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19900 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st40-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st40n-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with annotation 1 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18260 .
+_:g21680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> .
+_:g21680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18800 .
+_:g21960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst19n> .
+_:g21960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21220 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st35-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st35-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22680 .
+_:g19240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst34> .
+_:g19240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23460 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st28-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st28-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st28-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23340 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st21-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property that is on the top-level is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23480 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st04-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st04-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21040 .
+_:g21620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> .
+_:g21620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23400 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 3" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property multiple values" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22880 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st34-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st34-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <http://www.w3.org/2000/01/rdf-schema#comment> "node with @annotation property on node object with reverse relationship" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst34> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20860 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st35-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st35-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20180 .
+_:g19300 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19300 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st05-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st05-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22560 .
+_:g19500 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19500 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g18220 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g18220 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst09> .
+_:g19380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18040 .
+_:g19980 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19980 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st27a-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 9" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation that is an embedded node is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21740 .
+_:g17100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst16> .
+_:g17100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16720 .
+_:g20040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst04> .
+_:g20040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23320 .
+_:g19000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst20a> .
+_:g19000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22940 .
+_:g21600 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21600 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst16> .
+_:g23500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22660 .
+_:g20220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> .
+_:g20220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g21760 .
+_:g21440 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21440 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24a> .
+_:g22300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19780 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st37-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st37-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20380 .
+_:g23520 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23520 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19920 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19920 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st37-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st37-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for annotation node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node with an alias of `@annotation`" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst37> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20580 .
+_:g23540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst15> .
+_:g23540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23500 .
+_:g20740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst16> .
+_:g20740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19420 .
+_:g23560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst24> .
+_:g23560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20200 .
+_:g22380 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22380 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst33> .
+_:g23300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23580 .
+_:g23360 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23360 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st39-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st39-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation with embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <http://www.w3.org/2000/01/rdf-schema#comment> "annotation node containing an embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst39> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22460 .
+_:g21320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst40n> .
+_:g21320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20a-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20an-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 4 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing multiple properties" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20an> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22220 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st36-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st36-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Alias for embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with an alias of `@id`" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst36> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g21640 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st15-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st15-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 8" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst15> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17680 .
+_:g22840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> .
+_:g22840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g19160 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st18-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st18-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on value object" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst18> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23520 .
+_:g23280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> .
+_:g23280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23100 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st20b-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st20b-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Annotation node 5 (with @annotation)" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property containing an empty node object" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst20bn> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19620 .
+_:g23600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst36> .
+_:g23600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23420 .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st35-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st35-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st35-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17980 .
+_:g22020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst34n> .
+_:g22020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18760 .
+_:g20420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst09> .
+_:g20420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23140 .
+_:g22760 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22760 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22760 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst34> .
+_:g23580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23620 .
+_:g23640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#CompactTest> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/compact/st05-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/compact/st05-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#context> <https://json-ld.github.io/json-ld-star/tests/compact/st05-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 2" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having IRI @id" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst05> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23640 .
+_:g23380 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23380 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20000 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20000 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st03-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st03-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 2" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <http://www.w3.org/2000/01/rdf-schema#comment> "Value object with @annotation property is ignored without rdfstar option" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst03> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23660 .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FromRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st02-in.nq> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/fromRdf/st02-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "ignored annotation 1" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <http://www.w3.org/2000/01/rdf-schema#comment> "Node object with @annotation property is ignored without rdfstar option." .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst02> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23020 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st28-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st28-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded subject" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst28> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g17960 .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#FlattenTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/flatten/st08-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/flatten/st08-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 5" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having an IRI value" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst08> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19260 .
+_:g22980 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22980 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst35> .
+_:g23460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23600 .
+_:g19440 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19440 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20820 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20820 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st27a-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 9" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation that is an embedded node is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst27a> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23260 .
+_:g22900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38> .
+_:g22900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23680 .
+_:g23440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst38> .
+_:g23440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20140 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st35-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st35-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Reverse annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <http://www.w3.org/2000/01/rdf-schema#comment> "reverse relationship inside annotation" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst35> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g20940 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st04-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/expand/st04-out.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "embedded node 1" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with embedded subject having no @id" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst04> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18720 .
+_:g23700 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23700 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st25-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid set or list object" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 6" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <http://www.w3.org/2000/01/rdf-schema#comment> "@annotation on a list" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst25> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18200 .
+_:g20520 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g20520 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17540 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17540 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st29-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st29-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded annotation node 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on embedded object" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst29> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g18900 .
+_:g22340 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22340 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23720 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23720 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g20480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst23> .
+_:g20480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23560 .
+_:g17440 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g17440 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g22960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst21> .
+_:g22960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20460 .
+_:g23240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst21> .
+_:g23240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22600 .
+_:g22800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst13> .
+_:g22800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22520 .
+_:g23680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/flatten-manifest#tst38n> .
+_:g23680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18560 .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st24-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 4" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property with simple value is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst24> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23720 .
+_:g23480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ExpandTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/expand/st11-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 2" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having no property" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst11> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g23700 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st22-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid annotation" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Invalid annotation node 2" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <http://www.w3.org/2000/01/rdf-schema#comment> "Node with @annotation property on a top-level graph node is invalid" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst22> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19680 .
+_:g23620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst35> .
+_:g23620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g20300 .
+_:g16480 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g16480 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23200 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23200 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g19800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/expand-manifest#tst26> .
+_:g19800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g18320 .
+_:g22640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g16640 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g16640 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23660 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23660 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g17020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/compact-manifest#tst20b> .
+_:g17020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g16900 .
+_:g21080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g21080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st11-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid embedded node" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "invalid embedded node 2" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <http://www.w3.org/2000/01/rdf-schema#comment> "Illegal node with subject having no property" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst11> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g22400 .
+_:g22820 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g22820 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g23080 <https://w3c.github.io/json-ld-api/tests/vocab#createAnnotations> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23080 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g23080 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .
+_:g21780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst27> .
+_:g21780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g22540 .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://json-ld.github.io/json-ld-star/tests/toRdf/st38-in.jsonld> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://json-ld.github.io/json-ld-star/tests/toRdf/st38-out.nq> .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "annotation value 1" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <http://www.w3.org/2000/01/rdf-schema#comment> "embedded node with annotation on value object" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#requires> "JSON-LD*" .
+<https://json-ld.github.io/json-ld-star/tests/toRdf-manifest#tst38> <https://w3c.github.io/json-ld-api/tests/vocab#option> _:g19560 .
+_:g23120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://json-ld.github.io/json-ld-star/tests/fromRdf-manifest#tst10> .
+_:g23120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g23540 .
+_:g19740 <https://w3c.github.io/json-ld-api/tests/vocab#rdfstar> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:g19740 <https://w3c.github.io/json-ld-api/tests/vocab#specVersion> "json-ld*" .

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -15,7 +15,7 @@
     - tests['assertions'].each do |file|
       %link{rel: "related", href: file}
     %title
-      JSON-LD* Processor Conformance
+      JSON-LD-star Processor Conformance
     :css
       span[property='dc:description rdfs:comment'] { display: none; }
       td.PASS { color: green; }
@@ -91,9 +91,9 @@
         %a{href: "http://www.w3.org/"}
           %img{width: 72, height: 48, src: "https://www.w3.org/Icons/w3c_home", alt: "W3C"}
       %h1.title.p-name#title{property: "dc:title"}
-        JSON-LD* Processor Conformance
+        JSON-LD-star Processor Conformance
       %h2.subtitle
-        EARL results from the JSON-LD* Test Suite
+        EARL results from the JSON-LD-star Test Suite
       %h2#w3c-document-28-october-2015
         %time.dt-published{property: "dc:issued", datetime: Time.now.strftime('%Y-%m-%d')}
           = Time.now.strftime("%d %B %Y")
@@ -138,7 +138,7 @@
       %h2="Abstract"
       %p
         This document report test subject conformance for and related specifications for
-        %span{property: "doap:name"}<="JSON-LD* Test Suite"
+        %span{property: "doap:name"}<="JSON-LD-star Test Suite"
         according to the requirements of the Evaluation and Report Language (EARL) 1.0 Schema
         [
         %a{href: "https://www.w3.org/TR/EARL10-Schema/"}<>="EARL10-SCHEMA"
@@ -208,7 +208,7 @@
       :markdown
         ## Introduction
 
-        This implementation report covers the implementations of the JSON-LD*
+        This implementation report covers the implementations of the JSON-LD-star
         specification which have submitted test results. It is intended to be
         maintained by the [JSON for Linking Data Community Group](https://www.w3.org/community/json-ld/).
         The implementation report serves two purposes:
@@ -321,8 +321,8 @@
                   - other = []
                   - if option['https://w3c.github.io/json-ld-api/tests/vocab#specVersion'] == 'json-ld-1.1'
                     - other << "new in JSON-LD 1.1"
-                  - elsif option['https://w3c.github.io/json-ld-api/tests/vocab#specVersion'] == 'json-ld*'
-                    - other << "new in JSON-LD*"
+                  - elsif option['https://w3c.github.io/json-ld-aJSON-LD-starpi/tests/vocab#specVersion'] == 'json-ld-star'
+                    - other << "new in JSON-LD-star"
                   - if option['https://w3c.github.io/json-ld-api/tests/vocab#processorFeature']
                     - other << "feature: #{option['https://w3c.github.io/json-ld-api/tests/vocab#processorFeature']}"
                   - if !normative

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,13 +1,13 @@
 # Introduction
 
-The JSON-LD* Test Suite is a set of tests that can
-be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.
+The JSON-LD-star Test Suite is a set of tests that can
+be used to verify JSON-LD Processor for the RDF-star extensions to JSON-LD.
 
 More information and an RDFS definition of the test vocabulary can be found at [vocab](https://w3c.github.io/json-ld-api/tests/vocab).
 
 # Design
 
-Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the `rdfstar` option set to `true` for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF* mode.
+Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the `rdfstar` option set to `true` for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF-star mode.
 
 Tests driven from a top-level [manifest](manifest.jsonld) and are defined into [compact](compact-manifest.jsonld), [expand](expand-manifest.jsonld), [flatten](flatten-manifest.jsonld), [fromRdf](fromRdf-manifest.jsonld), and [toRdf](toRdf-manifest.jsonld) sections:
 

--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -15,7 +15,7 @@ Compaction
 </a>
 </p>
 <h1>Compaction</h1>
-<p>These tests implement the requirements for the JSON-LD* <a href="https://json-ld.github.io/json-ld-star#compaction-algorithm">Compaction Algorithm</a>.</p>
+<p>These tests implement the requirements for the JSON-LD-star <a href="https://json-ld.github.io/json-ld-star#compaction-algorithm">Compaction Algorithm</a>.</p>
 
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
 <a href="compact-manifest.jsonld">compact-manifest.jsonld</a>.
@@ -25,14 +25,14 @@ The manifest vocabulary is described in the
 <a href="ttp://w3c.github.io/json-ld-api/tests/vocab.ttl">Turtle</a>)
 and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
-<p>The JSON-LD* Test Suite is a set of tests that can
-be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
+<p>The JSON-LD-star Test Suite is a set of tests that can
+be used to verify JSON-LD Processor for the RDF-star extensions to JSON-LD.</p>
 
 <p>More information and an RDFS definition of the test vocabulary can be found at <a href="https://w3c.github.io/json-ld-api/tests/vocab">vocab</a>.</p>
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF* mode.</p>
+<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF-star mode.</p>
 
 <h1>Running tests</h1>
 
@@ -41,7 +41,8 @@ be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
 <p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
-<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term.</li>
+<li>For JSON-Ld-star tests, the <code>specVersion</code> is set to <code>JSON-LD-star</code>.</li>
+<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term. Tests that use JSON-LD-star functionality have <code>&quot;requires&quot;: &quot;JSON-LD-star&quot;</code> specified.</li>
 </ul>
 
 <h1>Contributing Tests</h1>
@@ -65,7 +66,11 @@ to the <a href="mailto:public-linked-json@w3.org">JSON-LD Community Group mailin
 <h2>Disclaimer</h2>
 
 <p>UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-  COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+
+<h2>Code of Conduct</h2>
+
+<p>W3C functions under a <a href="https://www.w3.org/Consortium/cepc/">code of conduct</a>.</p>
 
 <dl>
 <dt>baseIri</dt>
@@ -103,13 +108,13 @@ Test tst04 embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst05'>
@@ -139,13 +144,13 @@ Test tst05 embedded node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst06'>
@@ -175,13 +180,13 @@ Test tst06 embedded node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst07'>
@@ -211,13 +216,13 @@ Test tst07 embedded node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst08'>
@@ -247,13 +252,13 @@ Test tst08 embedded node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst09'>
@@ -283,13 +288,13 @@ Test tst09 embedded node 6
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst10'>
@@ -319,13 +324,13 @@ Test tst10 embedded node 7
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst15'>
@@ -355,13 +360,13 @@ Test tst15 embedded node 8
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst16'>
@@ -391,13 +396,13 @@ Test tst16 embedded node 9
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst17'>
@@ -427,13 +432,13 @@ Test tst17 embedded node 10
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst18'>
@@ -463,13 +468,13 @@ Test tst18 Annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst19'>
@@ -499,13 +504,13 @@ Test tst19 Annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20'>
@@ -535,13 +540,13 @@ Test tst20 Annotation node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20a'>
@@ -571,13 +576,13 @@ Test tst20a Annotation node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20b'>
@@ -607,13 +612,13 @@ Test tst20b Annotation node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst28'>
@@ -643,13 +648,13 @@ Test tst28 Embedded annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst29'>
@@ -679,13 +684,13 @@ Test tst29 Embedded annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst32'>
@@ -715,13 +720,13 @@ Test tst32 embedded node 13
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst33'>
@@ -751,13 +756,13 @@ Test tst33 embedded node 14
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst34'>
@@ -787,13 +792,13 @@ Test tst34 Reverse annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst35'>
@@ -823,13 +828,13 @@ Test tst35 Reverse annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst36'>
@@ -859,13 +864,13 @@ Test tst36 Alias for embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst37'>
@@ -895,13 +900,13 @@ Test tst37 Alias for annotation node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst38'>
@@ -931,13 +936,13 @@ Test tst38 annotation value 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst39'>
@@ -967,13 +972,13 @@ Test tst39 annotation with embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst40'>
@@ -1003,13 +1008,13 @@ Test tst40 annotation with annotation 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 </dl>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -3,7 +3,7 @@
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Compaction",
-  "description": "These tests implement the requirements for the JSON-LD* [Compaction Algorithm](https://json-ld.github.io/json-ld-star#compaction-algorithm).",
+  "description": "These tests implement the requirements for the JSON-LD-star [Compaction Algorithm](https://json-ld.github.io/json-ld-star#compaction-algorithm).",
   "baseIri": "https://json-ld.github.io/json-ld-star/tests/",
   "sequence": [
     {
@@ -14,8 +14,8 @@
       "input": "compact/st04-in.jsonld",
       "context": "compact/st04-out.jsonld",
       "expect": "compact/st04-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst05",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -24,8 +24,8 @@
       "input": "compact/st05-in.jsonld",
       "context": "compact/st05-out.jsonld",
       "expect": "compact/st05-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst06",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -34,8 +34,8 @@
       "input": "compact/st06-in.jsonld",
       "context": "compact/st06-out.jsonld",
       "expect": "compact/st06-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst07",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -44,8 +44,8 @@
       "input": "compact/st07-in.jsonld",
       "context": "compact/st07-out.jsonld",
       "expect": "compact/st07-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst08",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -54,8 +54,8 @@
       "input": "compact/st08-in.jsonld",
       "context": "compact/st08-out.jsonld",
       "expect": "compact/st08-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst09",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -64,8 +64,8 @@
       "input": "compact/st09-in.jsonld",
       "context": "compact/st09-out.jsonld",
       "expect": "compact/st09-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst10",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -74,8 +74,8 @@
       "input": "compact/st10-in.jsonld",
       "context": "compact/st10-out.jsonld",
       "expect": "compact/st10-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst15",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -84,8 +84,8 @@
       "input": "compact/st15-in.jsonld",
       "context": "compact/st15-out.jsonld",
       "expect": "compact/st15-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst16",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -94,8 +94,8 @@
       "input": "compact/st16-in.jsonld",
       "context": "compact/st16-out.jsonld",
       "expect": "compact/st16-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst17",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -104,8 +104,8 @@
       "input": "compact/st17-in.jsonld",
       "context": "compact/st17-out.jsonld",
       "expect": "compact/st17-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst18",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -114,8 +114,8 @@
       "input": "compact/st18-in.jsonld",
       "context": "compact/st18-out.jsonld",
       "expect": "compact/st18-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst19",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -124,8 +124,8 @@
       "input": "compact/st19-in.jsonld",
       "context": "compact/st19-out.jsonld",
       "expect": "compact/st19-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -134,8 +134,8 @@
       "input": "compact/st20-in.jsonld",
       "context": "compact/st20-out.jsonld",
       "expect": "compact/st20-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20a",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -144,8 +144,8 @@
       "input": "compact/st20a-in.jsonld",
       "context": "compact/st20a-out.jsonld",
       "expect": "compact/st20a-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20b",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -154,8 +154,8 @@
       "input": "compact/st20b-in.jsonld",
       "context": "compact/st20b-out.jsonld",
       "expect": "compact/st20b-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst28",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -164,8 +164,8 @@
       "input": "compact/st28-in.jsonld",
       "context": "compact/st28-out.jsonld",
       "expect": "compact/st28-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst29",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -174,8 +174,8 @@
       "input": "compact/st29-in.jsonld",
       "context": "compact/st29-out.jsonld",
       "expect": "compact/st29-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst32",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -184,8 +184,8 @@
       "input": "compact/st32-in.jsonld",
       "context": "compact/st32-out.jsonld",
       "expect": "compact/st32-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst33",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -194,8 +194,8 @@
       "input": "compact/st33-in.jsonld",
       "context": "compact/st33-out.jsonld",
       "expect": "compact/st33-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst34",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -204,8 +204,8 @@
       "input": "compact/st34-in.jsonld",
       "context": "compact/st34-out.jsonld",
       "expect": "compact/st34-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst35",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -214,8 +214,8 @@
       "input": "compact/st35-in.jsonld",
       "context": "compact/st35-out.jsonld",
       "expect": "compact/st35-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst36",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -224,8 +224,8 @@
       "input": "compact/st36-in.jsonld",
       "context": "compact/st36-out.jsonld",
       "expect": "compact/st36-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst37",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -234,8 +234,8 @@
       "input": "compact/st37-in.jsonld",
       "context": "compact/st37-out.jsonld",
       "expect": "compact/st37-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst38",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -244,8 +244,8 @@
       "input": "compact/st38-in.jsonld",
       "context": "compact/st38-out.jsonld",
       "expect": "compact/st38-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst39",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -254,8 +254,8 @@
       "input": "compact/st39-in.jsonld",
       "context": "compact/st39-out.jsonld",
       "expect": "compact/st39-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst40",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -264,8 +264,8 @@
       "input": "compact/st40-in.jsonld",
       "context": "compact/st40-out.jsonld",
       "expect": "compact/st40-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }
   ]
 }

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -15,7 +15,7 @@ Expansion
 </a>
 </p>
 <h1>Expansion</h1>
-<p>These tests implement the requirements for the JSON-LD* <a href="https://json-ld.github.io/json-ld-star#expansion-algorithm">Expansion Algorithm</a>.</p>
+<p>These tests implement the requirements for the JSON-LD-star <a href="https://json-ld.github.io/json-ld-star#expansion-algorithm">Expansion Algorithm</a>.</p>
 
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
 <a href="expand-manifest.jsonld">expand-manifest.jsonld</a>.
@@ -25,14 +25,14 @@ The manifest vocabulary is described in the
 <a href="ttp://w3c.github.io/json-ld-api/tests/vocab.ttl">Turtle</a>)
 and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
-<p>The JSON-LD* Test Suite is a set of tests that can
-be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
+<p>The JSON-LD-star Test Suite is a set of tests that can
+be used to verify JSON-LD Processor for the RDF-star extensions to JSON-LD.</p>
 
 <p>More information and an RDFS definition of the test vocabulary can be found at <a href="https://w3c.github.io/json-ld-api/tests/vocab">vocab</a>.</p>
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF* mode.</p>
+<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF-star mode.</p>
 
 <h1>Running tests</h1>
 
@@ -41,7 +41,8 @@ be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
 <p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
-<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term.</li>
+<li>For JSON-Ld-star tests, the <code>specVersion</code> is set to <code>JSON-LD-star</code>.</li>
+<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term. Tests that use JSON-LD-star functionality have <code>&quot;requires&quot;: &quot;JSON-LD-star&quot;</code> specified.</li>
 </ul>
 
 <h1>Contributing Tests</h1>
@@ -65,7 +66,11 @@ to the <a href="mailto:public-linked-json@w3.org">JSON-LD Community Group mailin
 <h2>Disclaimer</h2>
 
 <p>UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-  COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+
+<h2>Code of Conduct</h2>
+
+<p>W3C functions under a <a href="https://www.w3.org/Consortium/cepc/">code of conduct</a>.</p>
 
 <dl>
 <dt>baseIri</dt>
@@ -99,13 +104,13 @@ invalid @id value
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst02'>
@@ -131,13 +136,13 @@ Test tst02 ignored annotation 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst03'>
@@ -163,13 +168,13 @@ Test tst03 ignored annotation 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst04'>
@@ -195,13 +200,13 @@ Test tst04 embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst05'>
@@ -227,13 +232,13 @@ Test tst05 embedded node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst06'>
@@ -259,13 +264,13 @@ Test tst06 embedded node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst07'>
@@ -291,13 +296,13 @@ Test tst07 embedded node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst08'>
@@ -323,13 +328,13 @@ Test tst08 embedded node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst09'>
@@ -355,13 +360,13 @@ Test tst09 embedded node 6
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst10'>
@@ -387,13 +392,13 @@ Test tst10 embedded node 7
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst11'>
@@ -419,13 +424,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst12'>
@@ -451,13 +456,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst13'>
@@ -483,13 +488,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst14'>
@@ -515,13 +520,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst15'>
@@ -547,13 +552,13 @@ Test tst15 embedded node 8
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst16'>
@@ -579,13 +584,13 @@ Test tst16 embedded node 9
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst17'>
@@ -611,13 +616,13 @@ Test tst17 embedded node 10
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst18'>
@@ -643,13 +648,13 @@ Test tst18 Annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst19'>
@@ -675,13 +680,13 @@ Test tst19 Annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20'>
@@ -707,13 +712,13 @@ Test tst20 Annotation node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20a'>
@@ -739,13 +744,13 @@ Test tst20a Annotation node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20b'>
@@ -771,13 +776,13 @@ Test tst20b Annotation node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst21'>
@@ -803,13 +808,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst22'>
@@ -835,13 +840,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst23'>
@@ -867,13 +872,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst24'>
@@ -899,13 +904,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst24a'>
@@ -931,13 +936,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst25'>
@@ -963,13 +968,13 @@ invalid set or list object
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst26'>
@@ -995,13 +1000,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst27'>
@@ -1027,13 +1032,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst27a'>
@@ -1059,13 +1064,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst28'>
@@ -1091,13 +1096,13 @@ Test tst28 Embedded annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst29'>
@@ -1123,13 +1128,13 @@ Test tst29 Embedded annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst30'>
@@ -1155,13 +1160,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst31'>
@@ -1187,13 +1192,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst32'>
@@ -1219,13 +1224,13 @@ Test tst32 embedded node 13
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst33'>
@@ -1251,13 +1256,13 @@ Test tst33 embedded node 14
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst34'>
@@ -1283,13 +1288,13 @@ Test tst34 Reverse annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst35'>
@@ -1315,13 +1320,13 @@ Test tst35 Reverse annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst36'>
@@ -1347,13 +1352,13 @@ Test tst36 Alias for embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst37'>
@@ -1379,13 +1384,13 @@ Test tst37 Alias for annotation node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst38'>
@@ -1411,13 +1416,13 @@ Test tst38 annotation value 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst39'>
@@ -1443,13 +1448,13 @@ Test tst39 annotation with embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst40'>
@@ -1475,13 +1480,13 @@ Test tst40 annotation with annotation 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 </dl>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -3,7 +3,7 @@
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Expansion",
-  "description": "These tests implement the requirements for the JSON-LD* [Expansion Algorithm](https://json-ld.github.io/json-ld-star#expansion-algorithm).",
+  "description": "These tests implement the requirements for the JSON-LD-star [Expansion Algorithm](https://json-ld.github.io/json-ld-star#expansion-algorithm).",
   "baseIri": "https://w3c.github.io/json-ld-api/tests/",
   "sequence": [
     {
@@ -13,8 +13,8 @@
       "purpose": "Node with embedded subject without rdfstar option.",
       "input": "expand/st01-in.jsonld",
       "expectErrorCode": "invalid @id value",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst02",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -22,8 +22,8 @@
       "purpose": "Node object with @annotation property is ignored without rdfstar option.",
       "input": "expand/st02-in.jsonld",
       "expect": "expand/st02-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst03",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -31,8 +31,8 @@
       "purpose": "Value object with @annotation property is ignored without rdfstar option",
       "input": "expand/st03-in.jsonld",
       "expect": "expand/st03-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst04",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -40,8 +40,8 @@
       "purpose": "Node with embedded subject having no @id",
       "input": "expand/st04-in.jsonld",
       "expect": "expand/st04-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst05",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -49,8 +49,8 @@
       "purpose": "Node with embedded subject having IRI @id",
       "input": "expand/st05-in.jsonld",
       "expect": "expand/st05-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst06",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -58,8 +58,8 @@
       "purpose": "Node with embedded subject having BNode @id",
       "input": "expand/st06-in.jsonld",
       "expect": "expand/st06-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst07",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -67,8 +67,8 @@
       "purpose": "Node with embedded subject having a type",
       "input": "expand/st07-in.jsonld",
       "expect": "expand/st07-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst08",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -76,8 +76,8 @@
       "purpose": "Node with embedded subject having an IRI value",
       "input": "expand/st08-in.jsonld",
       "expect": "expand/st08-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst09",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -85,8 +85,8 @@
       "purpose": "Node with embedded subject having an BNode value",
       "input": "expand/st09-in.jsonld",
       "expect": "expand/st09-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst10",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -94,8 +94,8 @@
       "purpose": "Node with recursive embedded subject",
       "input": "expand/st10-in.jsonld",
       "expect": "expand/st10-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst11",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -103,8 +103,8 @@
       "purpose": "Illegal node with subject having no property",
       "input": "expand/st11-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst12",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -112,8 +112,8 @@
       "purpose": "Illegal node with subject having multiple properties",
       "input": "expand/st12-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst13",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -121,8 +121,8 @@
       "purpose": "Illegal node with subject having multiple types",
       "input": "expand/st13-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst14",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -130,8 +130,8 @@
       "purpose": "Illegal node with subject having type and property",
       "input": "expand/st14-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst15",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -139,8 +139,8 @@
       "purpose": "Node with embedded object",
       "input": "expand/st15-in.jsonld",
       "expect": "expand/st15-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst16",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -148,8 +148,8 @@
       "purpose": "Node with embedded object having properties",
       "input": "expand/st16-in.jsonld",
       "expect": "expand/st16-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst17",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -157,8 +157,8 @@
       "purpose": "Node with recursive embedded object",
       "input": "expand/st17-in.jsonld",
       "expect": "expand/st17-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst18",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -166,8 +166,8 @@
       "purpose": "Node with @annotation property on value object",
       "input": "expand/st18-in.jsonld",
       "expect": "expand/st18-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst19",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -175,8 +175,8 @@
       "purpose": "Node with @annotation property on node object",
       "input": "expand/st19-in.jsonld",
       "expect": "expand/st19-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -184,8 +184,8 @@
       "purpose": "Node with @annotation property multiple values",
       "input": "expand/st20-in.jsonld",
       "expect": "expand/st20-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20a",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -193,8 +193,8 @@
       "purpose": "Node with @annotation property containing multiple properties",
       "input": "expand/st20a-in.jsonld",
       "expect": "expand/st20a-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20b",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -202,8 +202,8 @@
       "purpose": "Node with @annotation property containing an empty node object",
       "input": "expand/st20b-in.jsonld",
       "expect": "expand/st20b-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst21",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -211,8 +211,8 @@
       "purpose": "Node with @annotation property that is on the top-level is invalid",
       "input": "expand/st21-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst22",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -220,8 +220,8 @@
       "purpose": "Node with @annotation property on a top-level graph node is invalid",
       "input": "expand/st22-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst23",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -229,8 +229,8 @@
       "purpose": "Node with @annotation property having @id is invalid",
       "input": "expand/st23-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst24",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -238,8 +238,8 @@
       "purpose": "Node with @annotation property with simple value is invalid",
       "input": "expand/st24-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst24a",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -247,8 +247,8 @@
       "purpose": "Node with @annotation property with value object value is invalid",
       "input": "expand/st24a-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst25",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -256,8 +256,8 @@
       "purpose": "@annotation on a list",
       "input": "expand/st25-in.jsonld",
       "expectErrorCode": "invalid set or list object",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst26",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -265,8 +265,8 @@
       "purpose": "Node with @annotation on a list value",
       "input": "expand/st26-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst27",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -274,8 +274,8 @@
       "purpose": "@annotation property on a top-level @included node is invalid",
       "input": "expand/st27-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst27a",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -283,8 +283,8 @@
       "purpose": "Node with @annotation that is an embedded node is invalid",
       "input": "expand/st27a-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst28",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -292,8 +292,8 @@
       "purpose": "Node with @annotation property on embedded subject",
       "input": "expand/st28-in.jsonld",
       "expect": "expand/st28-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst29",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -301,8 +301,8 @@
       "purpose": "Node with @annotation property on embedded object",
       "input": "expand/st29-in.jsonld",
       "expect": "expand/st29-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst30",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -310,8 +310,8 @@
       "purpose": "Embedded node with reverse relationship",
       "input": "expand/st30-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst31",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -319,8 +319,8 @@
       "purpose": "Embedded node with expanded reverse relationship",
       "input": "expand/st31-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst32",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -328,8 +328,8 @@
       "purpose": "Embedded node used as subject in reverse relationship",
       "input": "expand/st32-in.jsonld",
       "expect": "expand/st32-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst33",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -337,8 +337,8 @@
       "purpose": "Embedded node used as object in reverse relationship",
       "input": "expand/st33-in.jsonld",
       "expect": "expand/st33-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst34",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -346,8 +346,8 @@
       "purpose": "node with @annotation property on node object with reverse relationship",
       "input": "expand/st34-in.jsonld",
       "expect": "expand/st34-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst35",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -355,8 +355,8 @@
       "purpose": "reverse relationship inside annotation",
       "input": "expand/st35-in.jsonld",
       "expect": "expand/st35-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst36",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -364,8 +364,8 @@
       "purpose": "embedded node with an alias of `@id`",
       "input": "expand/st36-in.jsonld",
       "expect": "expand/st36-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst37",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -373,8 +373,8 @@
       "purpose": "annotation node with an alias of `@annotation`",
       "input": "expand/st37-in.jsonld",
       "expect": "expand/st37-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst38",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -382,8 +382,8 @@
       "purpose": "embedded node with annotation on value object",
       "input": "expand/st38-in.jsonld",
       "expect": "expand/st38-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst39",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -391,8 +391,8 @@
       "purpose": "annotation node containing an embedded node",
       "input": "expand/st39-in.jsonld",
       "expect": "expand/st39-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst40",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -400,8 +400,8 @@
       "purpose": "annotation node containing an annotation node",
       "input": "expand/st40-in.jsonld",
       "expect": "expand/st40-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }
   ]
 }

--- a/tests/flatten-manifest.html
+++ b/tests/flatten-manifest.html
@@ -15,7 +15,7 @@ Flattening
 </a>
 </p>
 <h1>Flattening</h1>
-<p>These tests implement the requirements for the JSON-LD* <a href="https://json-ld.github.io/json-ld-star#flattening-algorithm">Flattening Algorithm</a>.</p>
+<p>These tests implement the requirements for the JSON-LD-star <a href="https://json-ld.github.io/json-ld-star#flattening-algorithm">Flattening Algorithm</a>.</p>
 
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
 <a href="flatten-manifest.jsonld">flatten-manifest.jsonld</a>.
@@ -25,14 +25,14 @@ The manifest vocabulary is described in the
 <a href="ttp://w3c.github.io/json-ld-api/tests/vocab.ttl">Turtle</a>)
 and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
-<p>The JSON-LD* Test Suite is a set of tests that can
-be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
+<p>The JSON-LD-star Test Suite is a set of tests that can
+be used to verify JSON-LD Processor for the RDF-star extensions to JSON-LD.</p>
 
 <p>More information and an RDFS definition of the test vocabulary can be found at <a href="https://w3c.github.io/json-ld-api/tests/vocab">vocab</a>.</p>
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF* mode.</p>
+<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF-star mode.</p>
 
 <h1>Running tests</h1>
 
@@ -41,7 +41,8 @@ be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
 <p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
-<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term.</li>
+<li>For JSON-Ld-star tests, the <code>specVersion</code> is set to <code>JSON-LD-star</code>.</li>
+<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term. Tests that use JSON-LD-star functionality have <code>&quot;requires&quot;: &quot;JSON-LD-star&quot;</code> specified.</li>
 </ul>
 
 <h1>Contributing Tests</h1>
@@ -65,7 +66,11 @@ to the <a href="mailto:public-linked-json@w3.org">JSON-LD Community Group mailin
 <h2>Disclaimer</h2>
 
 <p>UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-  COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+
+<h2>Code of Conduct</h2>
+
+<p>W3C functions under a <a href="https://www.w3.org/Consortium/cepc/">code of conduct</a>.</p>
 
 <dl>
 <dt>baseIri</dt>
@@ -99,13 +104,13 @@ Test tst02 ignored annotation 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst03'>
@@ -131,13 +136,13 @@ Test tst03 ignored annotation 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst04'>
@@ -163,13 +168,13 @@ Test tst04 embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst05'>
@@ -195,13 +200,13 @@ Test tst05 embedded node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst06'>
@@ -227,13 +232,13 @@ Test tst06 embedded node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst07'>
@@ -259,13 +264,13 @@ Test tst07 embedded node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst08'>
@@ -291,13 +296,13 @@ Test tst08 embedded node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst09'>
@@ -323,13 +328,13 @@ Test tst09 embedded node 6
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst10'>
@@ -355,13 +360,13 @@ Test tst10 embedded node 7
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst15'>
@@ -387,13 +392,13 @@ Test tst15 embedded node 8
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst16'>
@@ -419,13 +424,13 @@ Test tst16 embedded node 9
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst17'>
@@ -451,13 +456,13 @@ Test tst17 embedded node 10
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst18'>
@@ -483,13 +488,13 @@ Test tst18 Annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst18n'>
@@ -515,7 +520,7 @@ Test tst18n Annotation node 1 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -523,7 +528,7 @@ Test tst18n Annotation node 1 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst19'>
@@ -549,13 +554,13 @@ Test tst19 Annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst19n'>
@@ -581,7 +586,7 @@ Test tst19n Annotation node 2 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -589,7 +594,7 @@ Test tst19n Annotation node 2 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20'>
@@ -615,13 +620,13 @@ Test tst20 Annotation node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20n'>
@@ -647,7 +652,7 @@ Test tst20n Annotation node 3 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -655,7 +660,7 @@ Test tst20n Annotation node 3 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20a'>
@@ -681,13 +686,13 @@ Test tst20a Annotation node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20an'>
@@ -713,7 +718,7 @@ Test tst20an Annotation node 4 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -721,7 +726,7 @@ Test tst20an Annotation node 4 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20b'>
@@ -747,13 +752,13 @@ Test tst20b Annotation node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20bn'>
@@ -779,7 +784,7 @@ Test tst20bn Annotation node 5 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -787,7 +792,7 @@ Test tst20bn Annotation node 5 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst28'>
@@ -813,13 +818,13 @@ Test tst28 Embedded annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst28n'>
@@ -845,7 +850,7 @@ Test tst28n Embedded annotation node 1 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -853,7 +858,7 @@ Test tst28n Embedded annotation node 1 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst29'>
@@ -879,13 +884,13 @@ Test tst29 Embedded annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst29n'>
@@ -911,7 +916,7 @@ Test tst29n Embedded annotation node 2 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -919,7 +924,7 @@ Test tst29n Embedded annotation node 2 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst32'>
@@ -945,13 +950,13 @@ Test tst32 embedded node 13
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst33'>
@@ -977,13 +982,13 @@ Test tst33 embedded node 14
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst34'>
@@ -1009,13 +1014,13 @@ Test tst34 Reverse annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst34n'>
@@ -1041,7 +1046,7 @@ Test tst34n Reverse annotation node 1 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -1049,7 +1054,7 @@ Test tst34n Reverse annotation node 1 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst35'>
@@ -1075,13 +1080,13 @@ Test tst35 Reverse annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst35n'>
@@ -1107,7 +1112,7 @@ Test tst35n Reverse annotation node 2 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -1115,7 +1120,7 @@ Test tst35n Reverse annotation node 2 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst36'>
@@ -1141,13 +1146,13 @@ Test tst36 Alias for embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst37'>
@@ -1173,13 +1178,13 @@ Test tst37 Alias for annotation node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst38'>
@@ -1205,13 +1210,13 @@ Test tst38 annotation value 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst38n'>
@@ -1237,7 +1242,7 @@ Test tst38n annotation value 1 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -1245,7 +1250,7 @@ Test tst38n annotation value 1 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst39'>
@@ -1271,13 +1276,13 @@ Test tst39 annotation with embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst39n'>
@@ -1303,7 +1308,7 @@ Test tst39n annotation with embedded node 1 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -1311,7 +1316,7 @@ Test tst39n annotation with embedded node 1 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst40'>
@@ -1337,13 +1342,13 @@ Test tst40 annotation with annotation 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst40n'>
@@ -1369,7 +1374,7 @@ Test tst40n annotation with annotation 1 (with @annotation)
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 <dt>createAnnotations</dt>
@@ -1377,7 +1382,7 @@ Test tst40n annotation with annotation 1 (with @annotation)
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 </dl>

--- a/tests/flatten-manifest.jsonld
+++ b/tests/flatten-manifest.jsonld
@@ -3,7 +3,7 @@
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Flattening",
-  "description": "These tests implement the requirements for the JSON-LD* [Flattening Algorithm](https://json-ld.github.io/json-ld-star#flattening-algorithm).",
+  "description": "These tests implement the requirements for the JSON-LD-star [Flattening Algorithm](https://json-ld.github.io/json-ld-star#flattening-algorithm).",
   "baseIri": "https://w3c.github.io/json-ld-api/tests/",
   "sequence": [
     {
@@ -13,8 +13,8 @@
       "purpose": "Node object with @annotation property is ignored without rdfstar option.",
       "input": "flatten/st02-in.jsonld",
       "expect": "flatten/st02-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst03",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -22,8 +22,8 @@
       "purpose": "Value object with @annotation property is ignored without rdfstar option",
       "input": "flatten/st03-in.jsonld",
       "expect": "flatten/st03-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst04",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -31,8 +31,8 @@
       "purpose": "Node with embedded subject having no @id",
       "input": "flatten/st04-in.jsonld",
       "expect": "flatten/st04-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst05",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -40,8 +40,8 @@
       "purpose": "Node with embedded subject having IRI @id",
       "input": "flatten/st05-in.jsonld",
       "expect": "flatten/st05-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst06",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -49,8 +49,8 @@
       "purpose": "Node with embedded subject having BNode @id",
       "input": "flatten/st06-in.jsonld",
       "expect": "flatten/st06-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst07",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -58,8 +58,8 @@
       "purpose": "Node with embedded subject having a type",
       "input": "flatten/st07-in.jsonld",
       "expect": "flatten/st07-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst08",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -67,8 +67,8 @@
       "purpose": "Node with embedded subject having an IRI value",
       "input": "flatten/st08-in.jsonld",
       "expect": "flatten/st08-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst09",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -76,8 +76,8 @@
       "purpose": "Node with embedded subject having an BNode value",
       "input": "flatten/st09-in.jsonld",
       "expect": "flatten/st09-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst10",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -85,8 +85,8 @@
       "purpose": "Node with recursive embedded subject",
       "input": "flatten/st10-in.jsonld",
       "expect": "flatten/st10-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst15",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -94,8 +94,8 @@
       "purpose": "Node with embedded object",
       "input": "flatten/st15-in.jsonld",
       "expect": "flatten/st15-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst16",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -103,8 +103,8 @@
       "purpose": "Node with embedded object having properties",
       "input": "flatten/st16-in.jsonld",
       "expect": "flatten/st16-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst17",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -112,8 +112,8 @@
       "purpose": "Node with recursive embedded object",
       "input": "flatten/st17-in.jsonld",
       "expect": "flatten/st17-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst18",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -121,8 +121,8 @@
       "purpose": "Node with @annotation property on value object",
       "input": "flatten/st18-in.jsonld",
       "expect": "flatten/st18-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst18n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -130,8 +130,8 @@
       "purpose": "Node with @annotation property on value object",
       "input": "flatten/st18-in.jsonld",
       "expect": "flatten/st18n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst19",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -139,8 +139,8 @@
       "purpose": "Node with @annotation property on node object",
       "input": "flatten/st19-in.jsonld",
       "expect": "flatten/st19-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst19n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -148,8 +148,8 @@
       "purpose": "Node with @annotation property on node object",
       "input": "flatten/st19-in.jsonld",
       "expect": "flatten/st19n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst20",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -157,8 +157,8 @@
       "purpose": "Node with @annotation property multiple values",
       "input": "flatten/st20-in.jsonld",
       "expect": "flatten/st20-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -166,8 +166,8 @@
       "purpose": "Node with @annotation property multiple values",
       "input": "flatten/st20-in.jsonld",
       "expect": "flatten/st20n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst20a",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -175,8 +175,8 @@
       "purpose": "Node with @annotation property containing multiple properties",
       "input": "flatten/st20a-in.jsonld",
       "expect": "flatten/st20a-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20an",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -184,8 +184,8 @@
       "purpose": "Node with @annotation property containing multiple properties",
       "input": "flatten/st20a-in.jsonld",
       "expect": "flatten/st20an-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst20b",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -193,8 +193,8 @@
       "purpose": "Node with @annotation property containing an empty node object",
       "input": "flatten/st20b-in.jsonld",
       "expect": "flatten/st20b-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20bn",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -202,8 +202,8 @@
       "purpose": "Node with @annotation property containing an empty node object",
       "input": "flatten/st20b-in.jsonld",
       "expect": "flatten/st20b-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst28",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -211,8 +211,8 @@
       "purpose": "Node with @annotation property on embedded subject",
       "input": "flatten/st28-in.jsonld",
       "expect": "flatten/st28-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst28n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -220,8 +220,8 @@
       "purpose": "Node with @annotation property on embedded subject",
       "input": "flatten/st28-in.jsonld",
       "expect": "flatten/st28n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst29",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -229,8 +229,8 @@
       "purpose": "Node with @annotation property on embedded object",
       "input": "flatten/st29-in.jsonld",
       "expect": "flatten/st29-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst29n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -238,8 +238,8 @@
       "purpose": "Node with @annotation property on embedded object",
       "input": "flatten/st29-in.jsonld",
       "expect": "flatten/st29n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst32",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -247,8 +247,8 @@
       "purpose": "Embedded node used as subject in reverse relationship",
       "input": "flatten/st32-in.jsonld",
       "expect": "flatten/st32-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst33",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -256,8 +256,8 @@
       "purpose": "Embedded node used as object in reverse relationship",
       "input": "flatten/st33-in.jsonld",
       "expect": "flatten/st33-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst34",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -265,8 +265,8 @@
       "purpose": "node with @annotation property on node object with reverse relationship",
       "input": "flatten/st34-in.jsonld",
       "expect": "flatten/st34-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst34n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -274,8 +274,8 @@
       "purpose": "node with @annotation property on node object with reverse relationship",
       "input": "flatten/st34-in.jsonld",
       "expect": "flatten/st34n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst35",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -283,8 +283,8 @@
       "purpose": "reverse relationship inside annotation",
       "input": "flatten/st35-in.jsonld",
       "expect": "flatten/st35-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst35n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -292,8 +292,8 @@
       "purpose": "reverse relationship inside annotation",
       "input": "flatten/st35-in.jsonld",
       "expect": "flatten/st35n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst36",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -301,8 +301,8 @@
       "purpose": "embedded node with an alias of `@id`",
       "input": "flatten/st36-in.jsonld",
       "expect": "flatten/st36-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst37",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -310,8 +310,8 @@
       "purpose": "annotation node with an alias of `@annotation`",
       "input": "flatten/st37-in.jsonld",
       "expect": "flatten/st37-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst38",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -319,8 +319,8 @@
       "purpose": "embedded node with annotation on value object",
       "input": "flatten/st38-in.jsonld",
       "expect": "flatten/st38-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst38n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -328,8 +328,8 @@
       "purpose": "embedded node with annotation on value object",
       "input": "flatten/st38-in.jsonld",
       "expect": "flatten/st38n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst39",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -337,8 +337,8 @@
       "purpose": "annotation node containing an embedded node",
       "input": "flatten/st39-in.jsonld",
       "expect": "flatten/st39-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst39n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -346,8 +346,8 @@
       "purpose": "annotation node containing an embedded node",
       "input": "flatten/st39-in.jsonld",
       "expect": "flatten/st39n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }, {
       "@id": "#tst40",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -355,8 +355,8 @@
       "purpose": "annotation node containing an annotation node",
       "input": "flatten/st40-in.jsonld",
       "expect": "flatten/st40-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst40n",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -364,8 +364,8 @@
       "purpose": "annotation node containing an annotation node",
       "input": "flatten/st40-in.jsonld",
       "expect": "flatten/st40n-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true, "createAnnotations": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true, "createAnnotations": true}
     }
   ]
 }

--- a/tests/fromRdf-manifest.html
+++ b/tests/fromRdf-manifest.html
@@ -15,7 +15,7 @@ Transform RDF to JSON-LD
 </a>
 </p>
 <h1>Transform RDF to JSON-LD</h1>
-<p>These tests implement the requirements for the JSON-LD* <a href="https://json-ld.github.io/json-ld-star#serialize-rdf-as-json-ld-algorithm">Serialize RDF as JSON-LD Algorithm</a>.</p>
+<p>These tests implement the requirements for the JSON-LD-star <a href="https://json-ld.github.io/json-ld-star#serialize-rdf-as-json-ld-algorithm">Serialize RDF as JSON-LD Algorithm</a>.</p>
 
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
 <a href="fromRdf-manifest.jsonld">fromRdf-manifest.jsonld</a>.
@@ -25,14 +25,14 @@ The manifest vocabulary is described in the
 <a href="ttp://w3c.github.io/json-ld-api/tests/vocab.ttl">Turtle</a>)
 and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
-<p>The JSON-LD* Test Suite is a set of tests that can
-be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
+<p>The JSON-LD-star Test Suite is a set of tests that can
+be used to verify JSON-LD Processor for the RDF-star extensions to JSON-LD.</p>
 
 <p>More information and an RDFS definition of the test vocabulary can be found at <a href="https://w3c.github.io/json-ld-api/tests/vocab">vocab</a>.</p>
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF* mode.</p>
+<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF-star mode.</p>
 
 <h1>Running tests</h1>
 
@@ -41,7 +41,8 @@ be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
 <p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
-<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term.</li>
+<li>For JSON-Ld-star tests, the <code>specVersion</code> is set to <code>JSON-LD-star</code>.</li>
+<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term. Tests that use JSON-LD-star functionality have <code>&quot;requires&quot;: &quot;JSON-LD-star&quot;</code> specified.</li>
 </ul>
 
 <h1>Contributing Tests</h1>
@@ -65,7 +66,11 @@ to the <a href="mailto:public-linked-json@w3.org">JSON-LD Community Group mailin
 <h2>Disclaimer</h2>
 
 <p>UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-  COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+
+<h2>Code of Conduct</h2>
+
+<p>W3C functions under a <a href="https://www.w3.org/Consortium/cepc/">code of conduct</a>.</p>
 
 <dl>
 <dt>baseIri</dt>
@@ -99,13 +104,13 @@ Test tst02 ignored annotation 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst03'>
@@ -131,13 +136,13 @@ Test tst03 ignored annotation 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst04'>
@@ -163,13 +168,13 @@ Test tst04 embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst05'>
@@ -195,13 +200,13 @@ Test tst05 embedded node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst06'>
@@ -227,13 +232,13 @@ Test tst06 embedded node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst07'>
@@ -259,13 +264,13 @@ Test tst07 embedded node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst08'>
@@ -291,13 +296,13 @@ Test tst08 embedded node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst09'>
@@ -323,13 +328,13 @@ Test tst09 embedded node 6
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst10'>
@@ -355,13 +360,13 @@ Test tst10 embedded node 7
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst15'>
@@ -387,13 +392,13 @@ Test tst15 embedded node 8
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst16'>
@@ -419,13 +424,13 @@ Test tst16 embedded node 9
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst17'>
@@ -451,13 +456,13 @@ Test tst17 embedded node 10
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst18'>
@@ -483,13 +488,13 @@ Test tst18 Annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst19'>
@@ -515,13 +520,13 @@ Test tst19 Annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20'>
@@ -547,13 +552,13 @@ Test tst20 Annotation node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20a'>
@@ -579,13 +584,13 @@ Test tst20a Annotation node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20b'>
@@ -611,13 +616,13 @@ Test tst20b Annotation node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst28'>
@@ -643,13 +648,13 @@ Test tst28 Embedded annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst29'>
@@ -675,13 +680,13 @@ Test tst29 Embedded annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst32'>
@@ -707,13 +712,13 @@ Test tst32 embedded node 13
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst33'>
@@ -739,13 +744,13 @@ Test tst33 embedded node 14
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst34'>
@@ -771,13 +776,13 @@ Test tst34 Reverse annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst35'>
@@ -803,13 +808,13 @@ Test tst35 Reverse annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst36'>
@@ -835,13 +840,13 @@ Test tst36 Alias for embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst37'>
@@ -867,13 +872,13 @@ Test tst37 Alias for annotation node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst38'>
@@ -899,13 +904,13 @@ Test tst38 annotation value 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst39'>
@@ -931,13 +936,13 @@ Test tst39 annotation with embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst40'>
@@ -963,13 +968,13 @@ Test tst40 annotation with annotation 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 </dl>

--- a/tests/fromRdf-manifest.jsonld
+++ b/tests/fromRdf-manifest.jsonld
@@ -3,7 +3,7 @@
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Transform RDF to JSON-LD",
-  "description": "These tests implement the requirements for the JSON-LD* [Serialize RDF as JSON-LD Algorithm](https://json-ld.github.io/json-ld-star#serialize-rdf-as-json-ld-algorithm).",
+  "description": "These tests implement the requirements for the JSON-LD-star [Serialize RDF as JSON-LD Algorithm](https://json-ld.github.io/json-ld-star#serialize-rdf-as-json-ld-algorithm).",
   "baseIri": "https://w3c.github.io/json-ld-api/tests/",
   "sequence": [
     {
@@ -13,8 +13,8 @@
       "purpose": "Node object with @annotation property is ignored without rdfstar option.",
       "input": "fromRdf/st02-in.nq",
       "expect": "fromRdf/st02-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst03",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -22,8 +22,8 @@
       "purpose": "Value object with @annotation property is ignored without rdfstar option",
       "input": "fromRdf/st03-in.nq",
       "expect": "fromRdf/st03-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst04",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -31,8 +31,8 @@
       "purpose": "Node with embedded subject having no @id",
       "input": "fromRdf/st04-in.nq",
       "expect": "fromRdf/st04-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst05",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -40,8 +40,8 @@
       "purpose": "Node with embedded subject having IRI @id",
       "input": "fromRdf/st05-in.nq",
       "expect": "fromRdf/st05-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst06",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -49,8 +49,8 @@
       "purpose": "Node with embedded subject having BNode @id",
       "input": "fromRdf/st06-in.nq",
       "expect": "fromRdf/st06-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst07",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -58,8 +58,8 @@
       "purpose": "Node with embedded subject having a type",
       "input": "fromRdf/st07-in.nq",
       "expect": "fromRdf/st07-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst08",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -67,8 +67,8 @@
       "purpose": "Node with embedded subject having an IRI value",
       "input": "fromRdf/st08-in.nq",
       "expect": "fromRdf/st08-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst09",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -76,8 +76,8 @@
       "purpose": "Node with embedded subject having an BNode value",
       "input": "fromRdf/st09-in.nq",
       "expect": "fromRdf/st09-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst10",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -85,8 +85,8 @@
       "purpose": "Node with recursive embedded subject",
       "input": "fromRdf/st10-in.nq",
       "expect": "fromRdf/st10-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst15",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -94,8 +94,8 @@
       "purpose": "Node with embedded object",
       "input": "fromRdf/st15-in.nq",
       "expect": "fromRdf/st15-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst16",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -103,8 +103,8 @@
       "purpose": "Node with embedded object having properties",
       "input": "fromRdf/st16-in.nq",
       "expect": "fromRdf/st16-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst17",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -112,8 +112,8 @@
       "purpose": "Node with recursive embedded object",
       "input": "fromRdf/st17-in.nq",
       "expect": "fromRdf/st17-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst18",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -121,8 +121,8 @@
       "purpose": "Node with @annotation property on value object",
       "input": "fromRdf/st18-in.nq",
       "expect": "fromRdf/st18-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst19",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -130,8 +130,8 @@
       "purpose": "Node with @annotation property on node object",
       "input": "fromRdf/st19-in.nq",
       "expect": "fromRdf/st19-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -139,8 +139,8 @@
       "purpose": "Node with @annotation property multiple values",
       "input": "fromRdf/st20-in.nq",
       "expect": "fromRdf/st20-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20a",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -148,8 +148,8 @@
       "purpose": "Node with @annotation property containing multiple properties",
       "input": "fromRdf/st20a-in.nq",
       "expect": "fromRdf/st20a-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20b",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -157,8 +157,8 @@
       "purpose": "Node with @annotation property containing an empty node object",
       "input": "fromRdf/st20b-in.nq",
       "expect": "fromRdf/st20b-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst28",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -166,8 +166,8 @@
       "purpose": "Node with @annotation property on embedded subject",
       "input": "fromRdf/st28-in.nq",
       "expect": "fromRdf/st28-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst29",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -175,8 +175,8 @@
       "purpose": "Node with @annotation property on embedded object",
       "input": "fromRdf/st29-in.nq",
       "expect": "fromRdf/st29-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst32",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -184,8 +184,8 @@
       "purpose": "Embedded node used as subject in reverse relationship",
       "input": "fromRdf/st32-in.nq",
       "expect": "fromRdf/st32-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst33",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -193,8 +193,8 @@
       "purpose": "Embedded node used as object in reverse relationship",
       "input": "fromRdf/st33-in.nq",
       "expect": "fromRdf/st33-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst34",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -202,8 +202,8 @@
       "purpose": "node with @annotation property on node object with reverse relationship",
       "input": "fromRdf/st34-in.nq",
       "expect": "fromRdf/st34-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst35",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -211,8 +211,8 @@
       "purpose": "reverse relationship inside annotation",
       "input": "fromRdf/st35-in.nq",
       "expect": "fromRdf/st35-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst36",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -220,8 +220,8 @@
       "purpose": "embedded node with an alias of `@id`",
       "input": "fromRdf/st36-in.nq",
       "expect": "fromRdf/st36-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst37",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -229,8 +229,8 @@
       "purpose": "annotation node with an alias of `@annotation`",
       "input": "fromRdf/st37-in.nq",
       "expect": "fromRdf/st37-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst38",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -238,8 +238,8 @@
       "purpose": "embedded node with annotation on value object",
       "input": "fromRdf/st38-in.nq",
       "expect": "fromRdf/st38-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst39",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -247,8 +247,8 @@
       "purpose": "annotation node containing an embedded node",
       "input": "fromRdf/st39-in.nq",
       "expect": "fromRdf/st39-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst40",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
@@ -256,8 +256,8 @@
       "purpose": "annotation node containing an annotation node",
       "input": "fromRdf/st40-in.nq",
       "expect": "fromRdf/st40-out.jsonld",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }
   ]
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,1 +1,0 @@
-manifest.html

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -3,7 +3,7 @@
 <head>
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
 <title>
-JSON-LD* Test Suite
+JSON-LD-star Test Suite
 </title>
 <link href='manifest.jsonld' rel='alternate'>
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet'>
@@ -14,8 +14,8 @@ JSON-LD* Test Suite
 <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
 </a>
 </p>
-<h1>JSON-LD* Test Suite</h1>
-<p>This manifest loads additional manifests for specific behavior tests for <a href="https://json-ld.github.io/json-ld-star">JSON-LD*</a></p>
+<h1>JSON-LD-star Test Suite</h1>
+<p>This manifest loads additional manifests for specific behavior tests for <a href="https://json-ld.github.io/json-ld-star">JSON-LD-star</a></p>
 
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
 <a href="manifest.jsonld">manifest.jsonld</a>.
@@ -25,14 +25,14 @@ The manifest vocabulary is described in the
 <a href="ttp://w3c.github.io/json-ld-api/tests/vocab.ttl">Turtle</a>)
 and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
-<p>The JSON-LD* Test Suite is a set of tests that can
-be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
+<p>The JSON-LD-star Test Suite is a set of tests that can
+be used to verify JSON-LD Processor for the RDF-star extensions to JSON-LD.</p>
 
 <p>More information and an RDFS definition of the test vocabulary can be found at <a href="https://w3c.github.io/json-ld-api/tests/vocab">vocab</a>.</p>
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF* mode.</p>
+<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF-star mode.</p>
 
 <h1>Running tests</h1>
 
@@ -41,7 +41,8 @@ be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
 <p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
-<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term.</li>
+<li>For JSON-Ld-star tests, the <code>specVersion</code> is set to <code>JSON-LD-star</code>.</li>
+<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term. Tests that use JSON-LD-star functionality have <code>&quot;requires&quot;: &quot;JSON-LD-star&quot;</code> specified.</li>
 </ul>
 
 <h1>Contributing Tests</h1>
@@ -65,7 +66,11 @@ to the <a href="mailto:public-linked-json@w3.org">JSON-LD Community Group mailin
 <h2>Disclaimer</h2>
 
 <p>UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-  COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+
+<h2>Code of Conduct</h2>
+
+<p>W3C functions under a <a href="https://www.w3.org/Consortium/cepc/">code of conduct</a>.</p>
 
 <section>
 <h2>

--- a/tests/manifest.jsonld
+++ b/tests/manifest.jsonld
@@ -2,8 +2,8 @@
   "@context": ["context.jsonld", {"@base": "manifest"}],
   "@id": "",
   "@type": "mf:Manifest",
-  "name": "JSON-LD* Test Suite",
-  "description": "This manifest loads additional manifests for specific behavior tests for [JSON-LD*](https://json-ld.github.io/json-ld-star)",
+  "name": "JSON-LD-star Test Suite",
+  "description": "This manifest loads additional manifests for specific behavior tests for [JSON-LD-star](https://json-ld.github.io/json-ld-star)",
   "sequence": [
     "compact-manifest.jsonld",
     "expand-manifest.jsonld",

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -25,14 +25,14 @@
       [Turtle](ttp://w3c.github.io/json-ld-api/tests/vocab.ttl))
       and is based on the [RDF Test Vocabulary](http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/).
 
-      The JSON-LD* Test Suite is a set of tests that can
-      be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.
+      The JSON-LD-star Test Suite is a set of tests that can
+      be used to verify JSON-LD Processor for the RDF-star extensions to JSON-LD.
 
       More information and an RDFS definition of the test vocabulary can be found at [vocab](https://w3c.github.io/json-ld-api/tests/vocab).
 
       ## General instructions for running the JSON-LD Test suites
 
-      Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the `rdfstar` option set to `true` for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF* mode.
+      Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the `rdfstar` option set to `true` for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF-star mode.
 
       # Running tests
 
@@ -40,7 +40,8 @@
 
       Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:
 
-      * Some tests may have a `requires` property, indicating some optional behavior described by a test vocabulary term.
+      * For JSON-Ld-star tests, the `specVersion` is set to `JSON-LD-star`.
+      * Some tests may have a `requires` property, indicating some optional behavior described by a test vocabulary term. Tests that use JSON-LD-star functionality have `"requires": "JSON-LD-star"` specified.
 
       # Contributing Tests
 
@@ -56,11 +57,17 @@
       
 
       ## Distribution
-        Distributed under the [W3C Test Suite License](http://www.w3.org/Consortium/Legal/2008/04-testsuite-license). To contribute to a W3C Test Suite, see the [policies and contribution forms](http://www.w3.org/2004/10/27-testcases).
+
+      Distributed under the [W3C Test Suite License](http://www.w3.org/Consortium/Legal/2008/04-testsuite-license). To contribute to a W3C Test Suite, see the [policies and contribution forms](http://www.w3.org/2004/10/27-testcases).
 
       ## Disclaimer
-        UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-        COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.
+
+      UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+      COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.
+
+      ## Code of Conduct
+
+      W3C functions under a [code of conduct](https://www.w3.org/Consortium/cepc/).
 
     - if manifest['baseIri']
       %dl

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -15,7 +15,7 @@ Transform JSON-LD to RDF
 </a>
 </p>
 <h1>Transform JSON-LD to RDF</h1>
-<p>These tests implement the requirements for the JSON-LD* <a href="https://json-ld.github.io/json-ld-star#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a>.</p>
+<p>These tests implement the requirements for the JSON-LD-star <a href="https://json-ld.github.io/json-ld-star#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a>.</p>
 
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
 <a href="toRdf-manifest.jsonld">toRdf-manifest.jsonld</a>.
@@ -25,14 +25,14 @@ The manifest vocabulary is described in the
 <a href="ttp://w3c.github.io/json-ld-api/tests/vocab.ttl">Turtle</a>)
 and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
-<p>The JSON-LD* Test Suite is a set of tests that can
-be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
+<p>The JSON-LD-star Test Suite is a set of tests that can
+be used to verify JSON-LD Processor for the RDF-star extensions to JSON-LD.</p>
 
 <p>More information and an RDFS definition of the test vocabulary can be found at <a href="https://w3c.github.io/json-ld-api/tests/vocab">vocab</a>.</p>
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF* mode.</p>
+<p>Tests are run broadly the same as those for the core JSON-LD test suite, with the addition of the <code>rdfstar</code> option set to <code>true</code> for each test. If not set, explicitly, the test checks for proper behavior when not operating in RDF-star mode.</p>
 
 <h1>Running tests</h1>
 
@@ -41,7 +41,8 @@ be used to verify JSON-LD Processor for the RDF* extensions to JSON-LD.</p>
 <p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
-<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term.</li>
+<li>For JSON-Ld-star tests, the <code>specVersion</code> is set to <code>JSON-LD-star</code>.</li>
+<li>Some tests may have a <code>requires</code> property, indicating some optional behavior described by a test vocabulary term. Tests that use JSON-LD-star functionality have <code>&quot;requires&quot;: &quot;JSON-LD-star&quot;</code> specified.</li>
 </ul>
 
 <h1>Contributing Tests</h1>
@@ -65,7 +66,11 @@ to the <a href="mailto:public-linked-json@w3.org">JSON-LD Community Group mailin
 <h2>Disclaimer</h2>
 
 <p>UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-  COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+
+<h2>Code of Conduct</h2>
+
+<p>W3C functions under a <a href="https://www.w3.org/Consortium/cepc/">code of conduct</a>.</p>
 
 <dl>
 <dt>baseIri</dt>
@@ -99,13 +104,13 @@ invalid @id value
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst02'>
@@ -131,13 +136,13 @@ Test tst02 ignored annotation 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst03'>
@@ -163,13 +168,13 @@ Test tst03 ignored annotation 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>false</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst04'>
@@ -195,13 +200,13 @@ Test tst04 embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst05'>
@@ -227,13 +232,13 @@ Test tst05 embedded node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst06'>
@@ -259,13 +264,13 @@ Test tst06 embedded node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst07'>
@@ -291,13 +296,13 @@ Test tst07 embedded node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst08'>
@@ -323,13 +328,13 @@ Test tst08 embedded node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst09'>
@@ -355,13 +360,13 @@ Test tst09 embedded node 6
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst10'>
@@ -387,13 +392,13 @@ Test tst10 embedded node 7
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst11'>
@@ -419,13 +424,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst12'>
@@ -451,13 +456,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst13'>
@@ -483,13 +488,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst14'>
@@ -515,13 +520,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst15'>
@@ -547,13 +552,13 @@ Test tst15 embedded node 8
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst16'>
@@ -579,13 +584,13 @@ Test tst16 embedded node 9
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst17'>
@@ -611,13 +616,13 @@ Test tst17 embedded node 10
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst18'>
@@ -643,13 +648,13 @@ Test tst18 Annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst19'>
@@ -675,13 +680,13 @@ Test tst19 Annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20'>
@@ -707,13 +712,13 @@ Test tst20 Annotation node 3
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20a'>
@@ -739,13 +744,13 @@ Test tst20a Annotation node 4
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst20b'>
@@ -771,13 +776,13 @@ Test tst20b Annotation node 5
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst21'>
@@ -803,13 +808,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst22'>
@@ -835,13 +840,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst23'>
@@ -867,13 +872,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst24'>
@@ -899,13 +904,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst24a'>
@@ -931,13 +936,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst25'>
@@ -963,13 +968,13 @@ invalid set or list object
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst26'>
@@ -995,13 +1000,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst27'>
@@ -1027,13 +1032,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst27a'>
@@ -1059,13 +1064,13 @@ invalid annotation
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst28'>
@@ -1091,13 +1096,13 @@ Test tst28 Embedded annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst29'>
@@ -1123,13 +1128,13 @@ Test tst29 Embedded annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst30'>
@@ -1155,13 +1160,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst31'>
@@ -1187,13 +1192,13 @@ invalid embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst32'>
@@ -1219,13 +1224,13 @@ Test tst32 embedded node 13
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst33'>
@@ -1251,13 +1256,13 @@ Test tst33 embedded node 14
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst34'>
@@ -1283,13 +1288,13 @@ Test tst34 Reverse annotation node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst35'>
@@ -1315,13 +1320,13 @@ Test tst35 Reverse annotation node 2
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst36'>
@@ -1347,13 +1352,13 @@ Test tst36 Alias for embedded node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst37'>
@@ -1379,13 +1384,13 @@ Test tst37 Alias for annotation node
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst38'>
@@ -1411,13 +1416,13 @@ Test tst38 annotation value 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst39'>
@@ -1443,13 +1448,13 @@ Test tst39 annotation with embedded node 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 <dt id='tst40'>
@@ -1475,13 +1480,13 @@ Test tst40 annotation with annotation 1
 <dd>
 <dl class='options'>
 <dt>specVersion</dt>
-<dd>json-ld*</dd>
+<dd>json-ld-star</dd>
 <dt>rdfstar</dt>
 <dd>true</dd>
 </dl>
 </dd>
 <dt>Requires</dt>
-<dd>JSON-LD*</dd>
+<dd>JSON-LD-star</dd>
 </dl>
 </dd>
 </dl>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -3,7 +3,7 @@
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Transform JSON-LD to RDF",
-  "description": "These tests implement the requirements for the JSON-LD* [Deserialize JSON-LD to RDF Algorithm](https://json-ld.github.io/json-ld-star#deserialize-json-ld-to-rdf-algorithm).",
+  "description": "These tests implement the requirements for the JSON-LD-star [Deserialize JSON-LD to RDF Algorithm](https://json-ld.github.io/json-ld-star#deserialize-json-ld-to-rdf-algorithm).",
   "baseIri": "https://w3c.github.io/json-ld-api/tests/",
   "sequence": [
     {
@@ -13,8 +13,8 @@
       "purpose": "Node with embedded subject without rdfstar option.",
       "input": "toRdf/st01-in.jsonld",
       "expectErrorCode": "invalid @id value",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst02",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -22,8 +22,8 @@
       "purpose": "Node object with @annotation property is ignored without rdfstar option.",
       "input": "toRdf/st02-in.jsonld",
       "expect": "toRdf/st02-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst03",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -31,8 +31,8 @@
       "purpose": "Value object with @annotation property is ignored without rdfstar option",
       "input": "toRdf/st03-in.jsonld",
       "expect": "toRdf/st03-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": false}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": false}
     }, {
       "@id": "#tst04",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -40,8 +40,8 @@
       "purpose": "Node with embedded subject having no @id",
       "input": "toRdf/st04-in.jsonld",
       "expect": "toRdf/st04-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst05",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -49,8 +49,8 @@
       "purpose": "Node with embedded subject having IRI @id",
       "input": "toRdf/st05-in.jsonld",
       "expect": "toRdf/st05-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst06",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -58,8 +58,8 @@
       "purpose": "Node with embedded subject having BNode @id",
       "input": "toRdf/st06-in.jsonld",
       "expect": "toRdf/st06-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst07",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -67,8 +67,8 @@
       "purpose": "Node with embedded subject having a type",
       "input": "toRdf/st07-in.jsonld",
       "expect": "toRdf/st07-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst08",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -76,8 +76,8 @@
       "purpose": "Node with embedded subject having an IRI value",
       "input": "toRdf/st08-in.jsonld",
       "expect": "toRdf/st08-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst09",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -85,8 +85,8 @@
       "purpose": "Node with embedded subject having an BNode value",
       "input": "toRdf/st09-in.jsonld",
       "expect": "toRdf/st09-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst10",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -94,8 +94,8 @@
       "purpose": "Node with recursive embedded subject",
       "input": "toRdf/st10-in.jsonld",
       "expect": "toRdf/st10-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst11",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -103,8 +103,8 @@
       "purpose": "Illegal node with subject having no property",
       "input": "toRdf/st11-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst12",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -112,8 +112,8 @@
       "purpose": "Illegal node with subject having multiple properties",
       "input": "toRdf/st12-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst13",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -121,8 +121,8 @@
       "purpose": "Illegal node with subject having multiple types",
       "input": "toRdf/st13-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst14",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -130,8 +130,8 @@
       "purpose": "Illegal node with subject having type and property",
       "input": "toRdf/st14-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst15",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -139,8 +139,8 @@
       "purpose": "Node with embedded object",
       "input": "toRdf/st15-in.jsonld",
       "expect": "toRdf/st15-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst16",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -148,8 +148,8 @@
       "purpose": "Node with embedded object having properties",
       "input": "toRdf/st16-in.jsonld",
       "expect": "toRdf/st16-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst17",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -157,8 +157,8 @@
       "purpose": "Node with recursive embedded object",
       "input": "toRdf/st17-in.jsonld",
       "expect": "toRdf/st17-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst18",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -166,8 +166,8 @@
       "purpose": "Node with @annotation property on value object",
       "input": "toRdf/st18-in.jsonld",
       "expect": "toRdf/st18-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst19",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -175,8 +175,8 @@
       "purpose": "Node with @annotation property on node object",
       "input": "toRdf/st19-in.jsonld",
       "expect": "toRdf/st19-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -184,8 +184,8 @@
       "purpose": "Node with @annotation property multiple values",
       "input": "toRdf/st20-in.jsonld",
       "expect": "toRdf/st20-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20a",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -193,8 +193,8 @@
       "purpose": "Node with @annotation property containing multiple properties",
       "input": "toRdf/st20a-in.jsonld",
       "expect": "toRdf/st20a-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst20b",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -202,8 +202,8 @@
       "purpose": "Node with @annotation property containing an empty node object",
       "input": "toRdf/st20b-in.jsonld",
       "expect": "toRdf/st20b-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst21",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -211,8 +211,8 @@
       "purpose": "Node with @annotation property that is on the top-level is invalid",
       "input": "toRdf/st21-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst22",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -220,8 +220,8 @@
       "purpose": "Node with @annotation property on a top-level graph node is invalid",
       "input": "toRdf/st22-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst23",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -229,8 +229,8 @@
       "purpose": "Node with @annotation property having @id is invalid",
       "input": "toRdf/st23-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst24",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -238,8 +238,8 @@
       "purpose": "Node with @annotation property with simple value is invalid",
       "input": "toRdf/st24-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst24a",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -247,8 +247,8 @@
       "purpose": "Node with @annotation property with value object value is invalid",
       "input": "toRdf/st24a-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst25",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -256,8 +256,8 @@
       "purpose": "@annotation on a list",
       "input": "toRdf/st25-in.jsonld",
       "expectErrorCode": "invalid set or list object",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst26",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -265,8 +265,8 @@
       "purpose": "Node with @annotation on a list value",
       "input": "toRdf/st26-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst27",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -274,8 +274,8 @@
       "purpose": "@annotation property on a top-level @included node is invalid",
       "input": "toRdf/st27-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst27a",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -283,8 +283,8 @@
       "purpose": "Node with @annotation that is an embedded node is invalid",
       "input": "toRdf/st27a-in.jsonld",
       "expectErrorCode": "invalid annotation",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst28",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -292,8 +292,8 @@
       "purpose": "Node with @annotation property on embedded subject",
       "input": "toRdf/st28-in.jsonld",
       "expect": "toRdf/st28-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst29",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -301,8 +301,8 @@
       "purpose": "Node with @annotation property on embedded object",
       "input": "toRdf/st29-in.jsonld",
       "expect": "toRdf/st29-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst30",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -310,8 +310,8 @@
       "purpose": "Embedded node with reverse relationship",
       "input": "toRdf/st30-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst31",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -319,8 +319,8 @@
       "purpose": "Embedded node with expanded reverse relationship",
       "input": "toRdf/st31-in.jsonld",
       "expectErrorCode": "invalid embedded node",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst32",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -328,8 +328,8 @@
       "purpose": "Embedded node used as subject in reverse relationship",
       "input": "toRdf/st32-in.jsonld",
       "expect": "toRdf/st32-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst33",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -337,8 +337,8 @@
       "purpose": "Embedded node used as object in reverse relationship",
       "input": "toRdf/st33-in.jsonld",
       "expect": "toRdf/st33-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst34",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -346,8 +346,8 @@
       "purpose": "node with @annotation property on node object with reverse relationship",
       "input": "toRdf/st34-in.jsonld",
       "expect": "toRdf/st34-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst35",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -355,8 +355,8 @@
       "purpose": "reverse relationship inside annotation",
       "input": "toRdf/st35-in.jsonld",
       "expect": "toRdf/st35-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst36",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -364,8 +364,8 @@
       "purpose": "embedded node with an alias of `@id`",
       "input": "toRdf/st36-in.jsonld",
       "expect": "toRdf/st36-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst37",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -373,8 +373,8 @@
       "purpose": "annotation node with an alias of `@annotation`",
       "input": "toRdf/st37-in.jsonld",
       "expect": "toRdf/st37-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst38",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -382,8 +382,8 @@
       "purpose": "embedded node with annotation on value object",
       "input": "toRdf/st38-in.jsonld",
       "expect": "toRdf/st38-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst39",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -391,8 +391,8 @@
       "purpose": "annotation node containing an embedded node",
       "input": "toRdf/st39-in.jsonld",
       "expect": "toRdf/st39-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }, {
       "@id": "#tst40",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -400,8 +400,8 @@
       "purpose": "annotation node containing an annotation node",
       "input": "toRdf/st40-in.jsonld",
       "expect": "toRdf/st40-out.nq",
-      "requires": "JSON-LD*",
-      "option": {"specVersion": "json-ld*", "rdfstar": true}
+      "requires": "JSON-LD-star",
+      "option": {"specVersion": "json-ld-star", "rdfstar": true}
     }
   ]
 }


### PR DESCRIPTION
@pchampin Also see ednote on aligning some concepts with RDF-star better.

After this, IMO, we can snapshot and notify the JSON-LD and RDF-DEV CGs and perhaps a call for implementations.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-star/pull/14.html" title="Last updated on Feb 13, 2021, 12:43 AM UTC (4a1ef85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-star/14/d82a87d...4a1ef85.html" title="Last updated on Feb 13, 2021, 12:43 AM UTC (4a1ef85)">Diff</a>