### PR TITLE
fix description of `@reverse` with annotation nodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@
       </aside>
 
       <p>Annotations may themselves use reverse properties, in which case
-        the annotated triple will be the subject (instead of the object) of the annotation:</p>
+        the annotated triple will be the object (instead of the subject) of the annotation:</p>
 
       <aside class="example ds-selector-tabs"
              title="Reversing annotations">


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-star/pull/26.html" title="Last updated on Dec 10, 2021, 2:23 PM UTC (fa60875)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/json-ld-star/26/b586fbf...fa60875.html" title="Last updated on Dec 10, 2021, 2:23 PM UTC (fa60875)">Diff</a>